### PR TITLE
feat: rename sys crate and always build/link cef_wrapper_lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,6 +502,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
+name = "download-cef"
+version = "1.0.0"
+dependencies = [
+ "bzip2",
+ "indicatif",
+ "serde",
+ "sha1_smol",
+ "tar",
+ "thiserror 2.0.11",
+ "ureq",
+]
+
+[[package]]
 name = "dpi"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1795,19 +1808,14 @@ name = "update-bindings"
 version = "131.3.4"
 dependencies = [
  "bindgen",
- "bzip2",
  "clap",
  "convert_case",
- "indicatif",
+ "download-cef",
  "proc-macro2",
  "quote",
  "regex",
- "serde_json",
- "sha1_smol",
  "syn",
- "tar",
  "thiserror 2.0.11",
- "ureq",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,39 +3,10 @@
 version = 4
 
 [[package]]
-name = "ab_glyph"
-version = "0.2.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3672c180e71eeaaac3a541fbbc5f5ad4def8b747c595ad30d674e43049f7b0"
-dependencies = [
- "ab_glyph_rasterizer",
- "owned_ttf_parser",
-]
-
-[[package]]
-name = "ab_glyph_rasterizer"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71b1793ee61086797f5c80b6efa2b8ffa6d5dd703f118545808a7f2e27f7046"
-
-[[package]]
 name = "adler2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
-
-[[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if",
- "getrandom",
- "once_cell",
- "version_check",
- "zerocopy",
-]
 
 [[package]]
 name = "aho-corasick"
@@ -45,33 +16,6 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "android-activity"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef6978589202a00cd7e118380c448a08b6ed394c3a8df3a430d0898e3a42d046"
-dependencies = [
- "android-properties",
- "bitflags 2.7.0",
- "cc",
- "cesu8",
- "jni",
- "jni-sys",
- "libc",
- "log",
- "ndk",
- "ndk-context",
- "ndk-sys",
- "num_enum",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "android-properties"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
 
 [[package]]
 name = "anstream"
@@ -123,34 +67,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayref"
-version = "0.3.9"
+name = "anyhow"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
-
-[[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
-name = "as-raw-xcb-connection"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
-
-[[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
-name = "autocfg"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "base64"
@@ -164,7 +84,7 @@ version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -180,42 +100,15 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1be3f42a67d6d345ecd59f675f3f012d6974981560836e938c22b424b85ce1be"
-
-[[package]]
-name = "block2"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
-dependencies = [
- "objc2",
-]
 
 [[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
-
-[[package]]
-name = "bytemuck"
-version = "1.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
-
-[[package]]
-name = "bytes"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "bzip2"
@@ -239,39 +132,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "calloop"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
-dependencies = [
- "bitflags 2.7.0",
- "log",
- "polling",
- "rustix",
- "slab",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "calloop-wayland-source"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
-dependencies = [
- "calloop",
- "rustix",
- "wayland-backend",
- "wayland-client",
-]
-
-[[package]]
 name = "cc"
 version = "1.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0cf6e91fde44c773c6ee7ec6bba798504641a8bc2eb7e37a04ffbf4dfaa55a"
 dependencies = [
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -279,15 +144,17 @@ dependencies = [
 name = "cef"
 version = "131.3.4"
 dependencies = [
- "libcef-sys",
- "winit",
+ "cef-dll-sys",
 ]
 
 [[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+name = "cef-dll-sys"
+version = "131.3.4"
+dependencies = [
+ "anyhow",
+ "cmake",
+ "download-cef",
+]
 
 [[package]]
 name = "cexpr"
@@ -303,12 +170,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clang-sys"
@@ -362,29 +223,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
+name = "cmake"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c682c223677e0e5b6b7f63a64b9351844c3f1b1678a68b7ee617e30fb082620e"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
-
-[[package]]
-name = "combine"
-version = "4.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
-dependencies = [
- "bytes",
- "memchr",
-]
-
-[[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
 
 [[package]]
 name = "console"
@@ -409,46 +260,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "core-graphics"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "core-graphics-types",
- "foreign-types",
- "libc",
-]
-
-[[package]]
-name = "core-graphics-types"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "libc",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -456,24 +267,6 @@ checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "cursor-icon"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
-
-[[package]]
-name = "dispatch"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
 name = "displaydoc"
@@ -487,21 +280,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dlib"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
-dependencies = [
- "libloading",
-]
-
-[[package]]
-name = "downcast-rs"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
-
-[[package]]
 name = "download-cef"
 version = "1.0.0"
 dependencies = [
@@ -510,15 +288,9 @@ dependencies = [
  "serde",
  "sha1_smol",
  "tar",
- "thiserror 2.0.11",
+ "thiserror",
  "ureq",
 ]
-
-[[package]]
-name = "dpi"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f25c0e292a7ca6d6498557ff1df68f32c99850012b6ea401cf8daf771f22ff53"
 
 [[package]]
 name = "either"
@@ -531,12 +303,6 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
-
-[[package]]
-name = "equivalent"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -571,49 +337,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "foreign-types"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
-dependencies = [
- "foreign-types-macros",
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-macros"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "gethostname"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818"
-dependencies = [
- "libc",
- "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -634,22 +363,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
-name = "hashbrown"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
-
-[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "icu_collections"
@@ -791,16 +508,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indexmap"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
-dependencies = [
- "equivalent",
- "hashbrown",
-]
-
-[[package]]
 name = "indicatif"
 version = "0.17.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -835,37 +542,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
-name = "jni"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
-dependencies = [
- "cesu8",
- "cfg-if",
- "combine",
- "jni-sys",
- "log",
- "thiserror 1.0.69",
- "walkdir",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
-
-[[package]]
-name = "jobserver"
-version = "0.1.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -882,20 +558,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
-name = "libcef-sys"
-version = "131.3.4"
-dependencies = [
- "winit",
-]
-
-[[package]]
 name = "libloading"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -904,9 +573,9 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags",
  "libc",
- "redox_syscall 0.5.8",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -934,15 +603,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
-name = "memmap2"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -958,36 +618,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ndk"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
-dependencies = [
- "bitflags 2.7.0",
- "jni-sys",
- "log",
- "ndk-sys",
- "num_enum",
- "raw-window-handle",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "ndk-context"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
-
-[[package]]
-name = "ndk-sys"
-version = "0.6.0+11769913"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
-dependencies = [
- "jni-sys",
-]
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -998,234 +628,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_enum"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
-dependencies = [
- "num_enum_derive",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
-name = "objc-sys"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
-
-[[package]]
-name = "objc2"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
-dependencies = [
- "objc-sys",
- "objc2-encode",
-]
-
-[[package]]
-name = "objc2-app-kit"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
-dependencies = [
- "bitflags 2.7.0",
- "block2",
- "libc",
- "objc2",
- "objc2-core-data",
- "objc2-core-image",
- "objc2-foundation",
- "objc2-quartz-core",
-]
-
-[[package]]
-name = "objc2-cloud-kit"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
-dependencies = [
- "bitflags 2.7.0",
- "block2",
- "objc2",
- "objc2-core-location",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-contacts"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
-dependencies = [
- "block2",
- "objc2",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-core-data"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
-dependencies = [
- "bitflags 2.7.0",
- "block2",
- "objc2",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-core-image"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
-dependencies = [
- "block2",
- "objc2",
- "objc2-foundation",
- "objc2-metal",
-]
-
-[[package]]
-name = "objc2-core-location"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
-dependencies = [
- "block2",
- "objc2",
- "objc2-contacts",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-encode"
-version = "4.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7891e71393cd1f227313c9379a26a584ff3d7e6e7159e988851f0934c993f0f8"
-
-[[package]]
-name = "objc2-foundation"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
-dependencies = [
- "bitflags 2.7.0",
- "block2",
- "dispatch",
- "libc",
- "objc2",
-]
-
-[[package]]
-name = "objc2-link-presentation"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
-dependencies = [
- "block2",
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-metal"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
-dependencies = [
- "bitflags 2.7.0",
- "block2",
- "objc2",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-quartz-core"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
-dependencies = [
- "bitflags 2.7.0",
- "block2",
- "objc2",
- "objc2-foundation",
- "objc2-metal",
-]
-
-[[package]]
-name = "objc2-symbols"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
-dependencies = [
- "objc2",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-ui-kit"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
-dependencies = [
- "bitflags 2.7.0",
- "block2",
- "objc2",
- "objc2-cloud-kit",
- "objc2-core-data",
- "objc2-core-image",
- "objc2-core-location",
- "objc2-foundation",
- "objc2-link-presentation",
- "objc2-quartz-core",
- "objc2-symbols",
- "objc2-uniform-type-identifiers",
- "objc2-user-notifications",
-]
-
-[[package]]
-name = "objc2-uniform-type-identifiers"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
-dependencies = [
- "block2",
- "objc2",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-user-notifications"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
-dependencies = [
- "bitflags 2.7.0",
- "block2",
- "objc2",
- "objc2-core-location",
- "objc2-foundation",
-]
 
 [[package]]
 name = "once_cell"
@@ -1234,75 +640,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
-name = "orbclient"
-version = "0.3.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba0b26cec2e24f08ed8bb31519a9333140a6599b867dac464bb150bdb796fd43"
-dependencies = [
- "libredox",
-]
-
-[[package]]
-name = "owned_ttf_parser"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec719bbf3b2a81c109a4e20b1f129b5566b7dce654bc3872f6a05abf82b2c4"
-dependencies = [
- "ttf-parser",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
-name = "pin-project"
-version = "1.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e2ec53ad785f4d35dac0adea7f7dc6f1bb277ad84a680c7afefeae05d1f5916"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
 name = "pkg-config"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
-
-[[package]]
-name = "polling"
-version = "3.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi",
- "pin-project-lite",
- "rustix",
- "tracing",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "portable-atomic"
@@ -1321,30 +668,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-crate"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
-dependencies = [
- "toml_edit",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.36.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -1357,27 +686,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "raw-window-handle"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
-
-[[package]]
-name = "redox_syscall"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -1436,7 +750,7 @@ version = "0.38.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1480,34 +794,6 @@ name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
-
-[[package]]
-name = "sctk-adwaita"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6277f0217056f77f1d8f49f2950ac6c278c0d607c45f5ee99328d792ede24ec"
-dependencies = [
- "ab_glyph",
- "log",
- "memmap2",
- "smithay-client-toolkit",
- "tiny-skia",
-]
 
 [[package]]
 name = "serde"
@@ -1554,53 +840,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "slab"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
-
-[[package]]
-name = "smithay-client-toolkit"
-version = "0.19.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
-dependencies = [
- "bitflags 2.7.0",
- "calloop",
- "calloop-wayland-source",
- "cursor-icon",
- "libc",
- "log",
- "memmap2",
- "rustix",
- "thiserror 1.0.69",
- "wayland-backend",
- "wayland-client",
- "wayland-csd-frame",
- "wayland-cursor",
- "wayland-protocols",
- "wayland-protocols-wlr",
- "wayland-scanner",
- "xkeysym",
-]
-
-[[package]]
-name = "smol_str"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "spin"
@@ -1613,12 +856,6 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "strict-num"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
 name = "strsim"
@@ -1667,31 +904,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
 dependencies = [
- "thiserror-impl 2.0.11",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -1706,31 +923,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiny-skia"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
-dependencies = [
- "arrayref",
- "arrayvec",
- "bytemuck",
- "cfg-if",
- "log",
- "tiny-skia-path",
-]
-
-[[package]]
-name = "tiny-skia-path"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
-dependencies = [
- "arrayref",
- "bytemuck",
- "strict-num",
-]
-
-[[package]]
 name = "tinystr"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1739,45 +931,6 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
-
-[[package]]
-name = "toml_edit"
-version = "0.22.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "winnow",
-]
-
-[[package]]
-name = "tracing"
-version = "0.1.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
-dependencies = [
- "pin-project-lite",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
-
-[[package]]
-name = "ttf-parser"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
 name = "unicode-ident"
@@ -1815,7 +968,7 @@ dependencies = [
  "quote",
  "regex",
  "syn",
- "thiserror 2.0.11",
+ "thiserror",
 ]
 
 [[package]]
@@ -1866,22 +1019,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
-
-[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1910,19 +1047,6 @@ dependencies = [
  "quote",
  "syn",
  "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.49"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
-dependencies = [
- "cfg-if",
- "js-sys",
- "once_cell",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -1955,125 +1079,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
 
 [[package]]
-name = "wayland-backend"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "056535ced7a150d45159d3a8dc30f91a2e2d588ca0b23f70e56033622b8016f6"
-dependencies = [
- "cc",
- "downcast-rs",
- "rustix",
- "scoped-tls",
- "smallvec",
- "wayland-sys",
-]
-
-[[package]]
-name = "wayland-client"
-version = "0.31.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66249d3fc69f76fd74c82cc319300faa554e9d865dab1f7cd66cc20db10b280"
-dependencies = [
- "bitflags 2.7.0",
- "rustix",
- "wayland-backend",
- "wayland-scanner",
-]
-
-[[package]]
-name = "wayland-csd-frame"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
-dependencies = [
- "bitflags 2.7.0",
- "cursor-icon",
- "wayland-backend",
-]
-
-[[package]]
-name = "wayland-cursor"
-version = "0.31.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b08bc3aafdb0035e7fe0fdf17ba0c09c268732707dca4ae098f60cb28c9e4c"
-dependencies = [
- "rustix",
- "wayland-client",
- "xcursor",
-]
-
-[[package]]
-name = "wayland-protocols"
-version = "0.32.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd0ade57c4e6e9a8952741325c30bf82f4246885dca8bf561898b86d0c1f58e"
-dependencies = [
- "bitflags 2.7.0",
- "wayland-backend",
- "wayland-client",
- "wayland-scanner",
-]
-
-[[package]]
-name = "wayland-protocols-plasma"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b31cab548ee68c7eb155517f2212049dc151f7cd7910c2b66abfd31c3ee12bd"
-dependencies = [
- "bitflags 2.7.0",
- "wayland-backend",
- "wayland-client",
- "wayland-protocols",
- "wayland-scanner",
-]
-
-[[package]]
-name = "wayland-protocols-wlr"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "782e12f6cd923c3c316130d56205ebab53f55d6666b7faddfad36cecaeeb4022"
-dependencies = [
- "bitflags 2.7.0",
- "wayland-backend",
- "wayland-client",
- "wayland-protocols",
- "wayland-scanner",
-]
-
-[[package]]
-name = "wayland-scanner"
-version = "0.31.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597f2001b2e5fc1121e3d5b9791d3e78f05ba6bfa4641053846248e3a13661c3"
-dependencies = [
- "proc-macro2",
- "quick-xml",
- "quote",
-]
-
-[[package]]
-name = "wayland-sys"
-version = "0.31.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efa8ac0d8e8ed3e3b5c9fc92c7881406a268e11555abe36493efabe649a29e09"
-dependencies = [
- "dlib",
- "log",
- "once_cell",
- "pkg-config",
-]
-
-[[package]]
-name = "web-sys"
-version = "0.3.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2093,30 +1098,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi-util"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
-dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
 name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2125,37 +1112,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2164,27 +1121,15 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2194,33 +1139,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2236,33 +1157,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2272,100 +1169,15 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winit"
-version = "0.30.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d74280aabb958072864bff6cfbcf9025cf8bfacdde5e32b5e12920ef703b0f"
-dependencies = [
- "ahash",
- "android-activity",
- "atomic-waker",
- "bitflags 2.7.0",
- "block2",
- "bytemuck",
- "calloop",
- "cfg_aliases",
- "concurrent-queue",
- "core-foundation",
- "core-graphics",
- "cursor-icon",
- "dpi",
- "js-sys",
- "libc",
- "memmap2",
- "ndk",
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
- "objc2-ui-kit",
- "orbclient",
- "percent-encoding",
- "pin-project",
- "raw-window-handle",
- "redox_syscall 0.4.1",
- "rustix",
- "sctk-adwaita",
- "smithay-client-toolkit",
- "smol_str",
- "tracing",
- "unicode-segmentation",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wayland-backend",
- "wayland-client",
- "wayland-protocols",
- "wayland-protocols-plasma",
- "web-sys",
- "web-time",
- "windows-sys 0.52.0",
- "x11-dl",
- "x11rb",
- "xkbcommon-dl",
-]
-
-[[package]]
-name = "winnow"
-version = "0.6.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "write16"
@@ -2380,38 +1192,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
-name = "x11-dl"
-version = "2.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38735924fedd5314a6e548792904ed8c6de6636285cb9fec04d5b1db85c1516f"
-dependencies = [
- "libc",
- "once_cell",
- "pkg-config",
-]
-
-[[package]]
-name = "x11rb"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d91ffca73ee7f68ce055750bf9f6eca0780b8c85eff9bc046a3b0da41755e12"
-dependencies = [
- "as-raw-xcb-connection",
- "gethostname",
- "libc",
- "libloading",
- "once_cell",
- "rustix",
- "x11rb-protocol",
-]
-
-[[package]]
-name = "x11rb-protocol"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec107c4503ea0b4a98ef47356329af139c0a4f7750e621cf2973cd3385ebcb3d"
-
-[[package]]
 name = "xattr"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2421,31 +1201,6 @@ dependencies = [
  "linux-raw-sys",
  "rustix",
 ]
-
-[[package]]
-name = "xcursor"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef33da6b1660b4ddbfb3aef0ade110c8b8a781a3b6382fa5f2b5b040fd55f61"
-
-[[package]]
-name = "xkbcommon-dl"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
-dependencies = [
- "bitflags 2.7.0",
- "dlib",
- "log",
- "once_cell",
- "xkeysym",
-]
-
-[[package]]
-name = "xkeysym"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yoke"
@@ -2469,26 +1224,6 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,7 +281,7 @@ dependencies = [
 
 [[package]]
 name = "download-cef"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "bzip2",
  "indicatif",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 
 members = [
+    "download-cef",
     "update-bindings",
     "sys",
     "cef",
@@ -20,4 +21,7 @@ repository = "https://github.com/tauri-apps/cef-rs"
 
 [workspace.dependencies]
 cef-sys = { package = "libcef-sys", version = "131.3.4", path = "sys" }
+download-cef = { version = "1.0.0", path = "download-cef" }
+serde = { version = "1.0", features = [ "derive" ] }
+thiserror = "2.0"
 winit = "0.30"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ repository = "https://github.com/tauri-apps/cef-rs"
 
 [workspace.dependencies]
 cef-dll-sys  = { version = "131.3.4", path = "sys" }
-download-cef = { version = "1", path = "download-cef" }
+download-cef = { version = "1.1", path = "download-cef" }
 
 anyhow = "1.0"
 bindgen = "0.71"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,17 @@ authors = [
 repository = "https://github.com/tauri-apps/cef-rs"
 
 [workspace.dependencies]
-cef-sys = { package = "libcef-sys", version = "131.3.4", path = "sys" }
-download-cef = { version = "1.0.0", path = "download-cef" }
+cef-dll-sys  = { version = "131.3.4", path = "sys" }
+download-cef = { version = "1", path = "download-cef" }
+
+anyhow = "1.0"
+bindgen = "0.71"
+clap = { version = "4.5", features = [ "derive" ] }
+cmake = "0.1"
+convert_case = "0.7"
+proc-macro2 = "1.0"
+quote = "1.0"
+regex = "1.0"
 serde = { version = "1.0", features = [ "derive" ] }
+syn = { version = "2.0", features = [ "full" ] }
 thiserror = "2.0"
-winit = "0.30"

--- a/cef/Cargo.toml
+++ b/cef/Cargo.toml
@@ -9,16 +9,13 @@ authors.workspace = true
 repository.workspace = true
 
 [features]
-dox = ["cef-sys/dox"]
+dox = ["cef-dll-sys/dox"]
 
 [package.metadata.docs.rs]
 features = [ "dox" ]
 
 [dependencies]
-cef-sys.workspace = true
-
-[dev-dependencies]
-winit.workspace = true
+cef-dll-sys.workspace = true
 
 [[example]]
 name = "cefsimple"

--- a/cef/examples/cefsimple/mac/helper.rs
+++ b/cef/examples/cefsimple/mac/helper.rs
@@ -1,18 +1,18 @@
 use cef::{execute_process, library_loader};
 use cef::{rc::*, *};
-use cef_sys::cef_sandbox_destroy;
+use cef_dll_sys::cef_sandbox_destroy;
 
-struct DemoApp(*mut RcImpl<cef_sys::_cef_app_t, Self>);
+struct DemoApp(*mut RcImpl<cef_dll_sys::_cef_app_t, Self>);
 
 impl WrapApp for DemoApp {
-    fn wrap_rc(&mut self, object: *mut RcImpl<cef_sys::_cef_app_t, Self>) {
+    fn wrap_rc(&mut self, object: *mut RcImpl<cef_dll_sys::_cef_app_t, Self>) {
         self.0 = object;
     }
 }
 
 impl ImplApp for DemoApp {
-    fn get_raw(&self) -> *mut cef_sys::_cef_app_t {
-        self.0 as *mut cef_sys::_cef_app_t
+    fn get_raw(&self) -> *mut cef_dll_sys::_cef_app_t {
+        self.0 as *mut cef_dll_sys::_cef_app_t
     }
 }
 
@@ -28,7 +28,7 @@ impl Clone for DemoApp {
 }
 
 impl Rc for DemoApp {
-    fn as_base(&self) -> &cef_sys::cef_base_ref_counted_t {
+    fn as_base(&self) -> &cef_dll_sys::cef_base_ref_counted_t {
         unsafe {
             let base = &*self.0;
             std::mem::transmute(&base.cef_object)

--- a/cef/examples/cefsimple/main.rs
+++ b/cef/examples/cefsimple/main.rs
@@ -2,7 +2,7 @@ use cef::{args::Args, rc::*, *};
 use std::sync::{Arc, Mutex};
 
 struct DemoApp {
-    object: *mut RcImpl<cef_sys::_cef_app_t, Self>,
+    object: *mut RcImpl<cef_dll_sys::_cef_app_t, Self>,
     window: Arc<Mutex<Option<Window>>>,
 }
 
@@ -16,7 +16,7 @@ impl DemoApp {
 }
 
 impl WrapApp for DemoApp {
-    fn wrap_rc(&mut self, object: *mut RcImpl<cef_sys::_cef_app_t, Self>) {
+    fn wrap_rc(&mut self, object: *mut RcImpl<cef_dll_sys::_cef_app_t, Self>) {
         self.object = object;
     }
 }
@@ -35,7 +35,7 @@ impl Clone for DemoApp {
 }
 
 impl Rc for DemoApp {
-    fn as_base(&self) -> &cef_sys::cef_base_ref_counted_t {
+    fn as_base(&self) -> &cef_dll_sys::cef_base_ref_counted_t {
         unsafe {
             let base = &*self.object;
             std::mem::transmute(&base.cef_object)
@@ -44,8 +44,8 @@ impl Rc for DemoApp {
 }
 
 impl ImplApp for DemoApp {
-    fn get_raw(&self) -> *mut cef_sys::_cef_app_t {
-        self.object as *mut cef_sys::_cef_app_t
+    fn get_raw(&self) -> *mut cef_dll_sys::_cef_app_t {
+        self.object as *mut cef_dll_sys::_cef_app_t
     }
 
     fn get_browser_process_handler(&self) -> Option<BrowserProcessHandler> {
@@ -54,7 +54,7 @@ impl ImplApp for DemoApp {
 }
 
 struct DemoBrowserProcessHandler {
-    object: *mut RcImpl<cef_sys::cef_browser_process_handler_t, Self>,
+    object: *mut RcImpl<cef_dll_sys::cef_browser_process_handler_t, Self>,
     window: Arc<Mutex<Option<Window>>>,
 }
 
@@ -68,7 +68,7 @@ impl DemoBrowserProcessHandler {
 }
 
 impl Rc for DemoBrowserProcessHandler {
-    fn as_base(&self) -> &cef_sys::cef_base_ref_counted_t {
+    fn as_base(&self) -> &cef_dll_sys::cef_base_ref_counted_t {
         unsafe {
             let base = &*self.object;
             std::mem::transmute(&base.cef_object)
@@ -77,7 +77,7 @@ impl Rc for DemoBrowserProcessHandler {
 }
 
 impl WrapBrowserProcessHandler for DemoBrowserProcessHandler {
-    fn wrap_rc(&mut self, object: *mut RcImpl<cef_sys::_cef_browser_process_handler_t, Self>) {
+    fn wrap_rc(&mut self, object: *mut RcImpl<cef_dll_sys::_cef_browser_process_handler_t, Self>) {
         self.object = object;
     }
 }
@@ -97,7 +97,7 @@ impl Clone for DemoBrowserProcessHandler {
 }
 
 impl ImplBrowserProcessHandler for DemoBrowserProcessHandler {
-    fn get_raw(&self) -> *mut cef_sys::_cef_browser_process_handler_t {
+    fn get_raw(&self) -> *mut cef_dll_sys::_cef_browser_process_handler_t {
         self.object.cast()
     }
 
@@ -126,7 +126,7 @@ impl ImplBrowserProcessHandler for DemoBrowserProcessHandler {
     }
 }
 
-struct DemoClient(*mut RcImpl<cef_sys::_cef_client_t, Self>);
+struct DemoClient(*mut RcImpl<cef_dll_sys::_cef_client_t, Self>);
 
 impl DemoClient {
     fn new() -> Client {
@@ -135,7 +135,7 @@ impl DemoClient {
 }
 
 impl WrapClient for DemoClient {
-    fn wrap_rc(&mut self, object: *mut RcImpl<cef_sys::_cef_client_t, Self>) {
+    fn wrap_rc(&mut self, object: *mut RcImpl<cef_dll_sys::_cef_client_t, Self>) {
         self.0 = object;
     }
 }
@@ -152,7 +152,7 @@ impl Clone for DemoClient {
 }
 
 impl Rc for DemoClient {
-    fn as_base(&self) -> &cef_sys::cef_base_ref_counted_t {
+    fn as_base(&self) -> &cef_dll_sys::cef_base_ref_counted_t {
         unsafe {
             let base = &*self.0;
             std::mem::transmute(&base.cef_object)
@@ -161,13 +161,13 @@ impl Rc for DemoClient {
 }
 
 impl ImplClient for DemoClient {
-    fn get_raw(&self) -> *mut cef_sys::_cef_client_t {
-        self.0 as *mut cef_sys::_cef_client_t
+    fn get_raw(&self) -> *mut cef_dll_sys::_cef_client_t {
+        self.0 as *mut cef_dll_sys::_cef_client_t
     }
 }
 
 struct DemoWindowDelegate {
-    base: *mut RcImpl<cef_sys::_cef_window_delegate_t, Self>,
+    base: *mut RcImpl<cef_dll_sys::_cef_window_delegate_t, Self>,
     browser_view: BrowserView,
 }
 
@@ -181,7 +181,7 @@ impl DemoWindowDelegate {
 }
 
 impl WrapWindowDelegate for DemoWindowDelegate {
-    fn wrap_rc(&mut self, object: *mut RcImpl<cef_sys::_cef_window_delegate_t, Self>) {
+    fn wrap_rc(&mut self, object: *mut RcImpl<cef_dll_sys::_cef_window_delegate_t, Self>) {
         self.base = object;
     }
 }
@@ -201,7 +201,7 @@ impl Clone for DemoWindowDelegate {
 }
 
 impl Rc for DemoWindowDelegate {
-    fn as_base(&self) -> &cef_sys::cef_base_ref_counted_t {
+    fn as_base(&self) -> &cef_dll_sys::cef_base_ref_counted_t {
         unsafe {
             let base = &*self.base;
             std::mem::transmute(&base.cef_object)
@@ -219,8 +219,8 @@ impl ImplViewDelegate for DemoWindowDelegate {
         // view.as_panel().map(|x| x.as_window().map(|w| w.close()));
     }
 
-    fn get_raw(&self) -> *mut cef_sys::_cef_view_delegate_t {
-        self.base as *mut cef_sys::_cef_view_delegate_t
+    fn get_raw(&self) -> *mut cef_dll_sys::_cef_view_delegate_t {
+        self.base as *mut cef_dll_sys::_cef_view_delegate_t
     }
 }
 

--- a/cef/src/bindings/aarch64_apple_darwin.rs
+++ b/cef/src/bindings/aarch64_apple_darwin.rs
@@ -5,7 +5,7 @@
     unused_variables
 )]
 use crate::rc::{ConvertParam, ConvertReturnValue, Rc, RcImpl, RefGuard, WrapParamRef};
-use cef_sys::*;
+use cef_dll_sys::*;
 
 /// Perform the conversion between CEF and Rust types in field initializers.
 fn init_array_field<T, U, const N: usize>(mut value: [U; N]) -> [T; N]

--- a/cef/src/bindings/aarch64_pc_windows_msvc.rs
+++ b/cef/src/bindings/aarch64_pc_windows_msvc.rs
@@ -5,7 +5,7 @@
     unused_variables
 )]
 use crate::rc::{ConvertParam, ConvertReturnValue, Rc, RcImpl, RefGuard, WrapParamRef};
-use cef_sys::*;
+use cef_dll_sys::*;
 
 /// Perform the conversion between CEF and Rust types in field initializers.
 fn init_array_field<T, U, const N: usize>(mut value: [U; N]) -> [T; N]

--- a/cef/src/bindings/aarch64_unknown_linux_gnu.rs
+++ b/cef/src/bindings/aarch64_unknown_linux_gnu.rs
@@ -5,7 +5,7 @@
     unused_variables
 )]
 use crate::rc::{ConvertParam, ConvertReturnValue, Rc, RcImpl, RefGuard, WrapParamRef};
-use cef_sys::*;
+use cef_dll_sys::*;
 
 /// Perform the conversion between CEF and Rust types in field initializers.
 fn init_array_field<T, U, const N: usize>(mut value: [U; N]) -> [T; N]

--- a/cef/src/bindings/arm_unknown_linux_gnueabi.rs
+++ b/cef/src/bindings/arm_unknown_linux_gnueabi.rs
@@ -5,7 +5,7 @@
     unused_variables
 )]
 use crate::rc::{ConvertParam, ConvertReturnValue, Rc, RcImpl, RefGuard, WrapParamRef};
-use cef_sys::*;
+use cef_dll_sys::*;
 
 /// Perform the conversion between CEF and Rust types in field initializers.
 fn init_array_field<T, U, const N: usize>(mut value: [U; N]) -> [T; N]

--- a/cef/src/bindings/i686_pc_windows_msvc.rs
+++ b/cef/src/bindings/i686_pc_windows_msvc.rs
@@ -5,7 +5,7 @@
     unused_variables
 )]
 use crate::rc::{ConvertParam, ConvertReturnValue, Rc, RcImpl, RefGuard, WrapParamRef};
-use cef_sys::*;
+use cef_dll_sys::*;
 
 /// Perform the conversion between CEF and Rust types in field initializers.
 fn init_array_field<T, U, const N: usize>(mut value: [U; N]) -> [T; N]

--- a/cef/src/bindings/i686_unknown_linux_gnu.rs
+++ b/cef/src/bindings/i686_unknown_linux_gnu.rs
@@ -5,7 +5,7 @@
     unused_variables
 )]
 use crate::rc::{ConvertParam, ConvertReturnValue, Rc, RcImpl, RefGuard, WrapParamRef};
-use cef_sys::*;
+use cef_dll_sys::*;
 
 /// Perform the conversion between CEF and Rust types in field initializers.
 fn init_array_field<T, U, const N: usize>(mut value: [U; N]) -> [T; N]

--- a/cef/src/bindings/x86_64_apple_darwin.rs
+++ b/cef/src/bindings/x86_64_apple_darwin.rs
@@ -5,7 +5,7 @@
     unused_variables
 )]
 use crate::rc::{ConvertParam, ConvertReturnValue, Rc, RcImpl, RefGuard, WrapParamRef};
-use cef_sys::*;
+use cef_dll_sys::*;
 
 /// Perform the conversion between CEF and Rust types in field initializers.
 fn init_array_field<T, U, const N: usize>(mut value: [U; N]) -> [T; N]

--- a/cef/src/bindings/x86_64_pc_windows_msvc.rs
+++ b/cef/src/bindings/x86_64_pc_windows_msvc.rs
@@ -5,7 +5,7 @@
     unused_variables
 )]
 use crate::rc::{ConvertParam, ConvertReturnValue, Rc, RcImpl, RefGuard, WrapParamRef};
-use cef_sys::*;
+use cef_dll_sys::*;
 
 /// Perform the conversion between CEF and Rust types in field initializers.
 fn init_array_field<T, U, const N: usize>(mut value: [U; N]) -> [T; N]

--- a/cef/src/bindings/x86_64_unknown_linux_gnu.rs
+++ b/cef/src/bindings/x86_64_unknown_linux_gnu.rs
@@ -5,7 +5,7 @@
     unused_variables
 )]
 use crate::rc::{ConvertParam, ConvertReturnValue, Rc, RcImpl, RefGuard, WrapParamRef};
-use cef_sys::*;
+use cef_dll_sys::*;
 
 /// Perform the conversion between CEF and Rust types in field initializers.
 fn init_array_field<T, U, const N: usize>(mut value: [U; N]) -> [T; N]

--- a/cef/src/lib.rs
+++ b/cef/src/lib.rs
@@ -11,4 +11,4 @@ pub mod library_loader;
 mod bindings;
 pub use bindings::*;
 
-pub use cef_sys as sys;
+pub use cef_dll_sys as sys;

--- a/cef/src/rc.rs
+++ b/cef/src/rc.rs
@@ -31,13 +31,13 @@
 //! Finally, define a method called `from_raw`. For more implementation details, please see the
 //! documentation of [`RefGuard`].
 //!
-//! [`cef_settings_t`]: cef_sys::cef_settings_t
-//! [`cef_window_delegate_t`]: cef_sys::cef_window_delegate_t
+//! [`cef_settings_t`]: cef_dll_sys::cef_settings_t
+//! [`cef_window_delegate_t`]: cef_dll_sys::cef_window_delegate_t
 //! [`Settings`]: crate::Settings
 //! [`WindowDelegate`]: crate::WindowDelegate
 //! [`WindowDelegate::on_window_created`]: crate::WindowDelegate::on_window_created
 //! [`into_raw`]: crate::WindowDelegate::into_raw
-//! [`cef_window_t`]: cef_sys::cef_window_t
+//! [`cef_window_t`]: cef_dll_sys::cef_window_t
 //! [`Window`]: crate::Window
 
 use std::{
@@ -47,7 +47,7 @@ use std::{
     sync::atomic::{fence, AtomicUsize, Ordering},
 };
 
-use cef_sys::cef_base_ref_counted_t;
+use cef_dll_sys::cef_base_ref_counted_t;
 
 /// Reference counted trait for types has [`cef_base_ref_counted_t`].
 pub trait Rc {

--- a/cef/src/string.rs
+++ b/cef/src/string.rs
@@ -1,6 +1,6 @@
 //! String module
 
-use cef_sys::{
+use cef_dll_sys::{
     _cef_string_list_t, _cef_string_map_t, _cef_string_multimap_t, _cef_string_utf16_t,
     _cef_string_utf8_t, _cef_string_wide_t,
 };
@@ -89,10 +89,10 @@ impl Drop for CefStringUtf8 {
                 CefStringData::UserFree(value) => {
                     value
                         .as_mut()
-                        .map(|value| cef_sys::cef_string_userfree_utf8_free(value));
+                        .map(|value| cef_dll_sys::cef_string_userfree_utf8_free(value));
                 }
                 CefStringData::Clear(value) => {
-                    cef_sys::cef_string_utf8_clear(value);
+                    cef_dll_sys::cef_string_utf8_clear(value);
                 }
                 _ => {}
             }
@@ -104,9 +104,9 @@ impl From<&str> for CefStringUtf8 {
     fn from(value: &str) -> Self {
         Self(
             unsafe {
-                let cef_string = cef_sys::cef_string_userfree_utf8_alloc();
+                let cef_string = cef_dll_sys::cef_string_userfree_utf8_alloc();
                 if !cef_string.is_null() {
-                    cef_sys::cef_string_utf8_set(
+                    cef_dll_sys::cef_string_utf8_set(
                         value.as_bytes().as_ptr() as *const _,
                         value.as_bytes().len(),
                         cef_string,
@@ -153,7 +153,7 @@ impl From<&CefStringUtf16> for CefStringUtf8 {
                 let value: *const _cef_string_utf16_t = value.into();
                 if let Some((str_, length)) = value.as_ref().map(|value| (value.str_, value.length))
                 {
-                    cef_sys::cef_string_utf16_to_utf8(str_, length, cef_string);
+                    cef_dll_sys::cef_string_utf16_to_utf8(str_, length, cef_string);
                 }
                 cef_string
             }
@@ -170,7 +170,7 @@ impl From<&CefStringWide> for CefStringUtf8 {
                 let value: *const _cef_string_wide_t = value.into();
                 if let Some((str_, length)) = value.as_ref().map(|value| (value.str_, value.length))
                 {
-                    cef_sys::cef_string_wide_to_utf8(str_, length, cef_string);
+                    cef_dll_sys::cef_string_wide_to_utf8(str_, length, cef_string);
                 }
                 cef_string
             }
@@ -237,10 +237,10 @@ impl Drop for CefStringUtf16 {
                 CefStringData::UserFree(value) => {
                     value
                         .as_mut()
-                        .map(|value| cef_sys::cef_string_userfree_utf16_free(value));
+                        .map(|value| cef_dll_sys::cef_string_userfree_utf16_free(value));
                 }
                 CefStringData::Clear(value) => {
-                    cef_sys::cef_string_utf16_clear(value);
+                    cef_dll_sys::cef_string_utf16_clear(value);
                 }
                 _ => {}
             }
@@ -286,7 +286,7 @@ impl From<&CefStringUtf8> for CefStringUtf16 {
                 let value: *const _cef_string_utf8_t = value.into();
                 if let Some((str_, length)) = value.as_ref().map(|value| (value.str_, value.length))
                 {
-                    cef_sys::cef_string_utf8_to_utf16(str_, length, &mut cef_string);
+                    cef_dll_sys::cef_string_utf8_to_utf16(str_, length, &mut cef_string);
                 }
                 cef_string
             }
@@ -303,7 +303,7 @@ impl From<&CefStringWide> for CefStringUtf16 {
                 let value: *const _cef_string_wide_t = value.into();
                 if let Some((str_, length)) = value.as_ref().map(|value| (value.str_, value.length))
                 {
-                    cef_sys::cef_string_wide_to_utf16(str_, length, &mut cef_string);
+                    cef_dll_sys::cef_string_wide_to_utf16(str_, length, &mut cef_string);
                 }
                 cef_string
             }
@@ -349,10 +349,10 @@ impl Drop for CefStringWide {
                 CefStringData::UserFree(value) => {
                     value
                         .as_mut()
-                        .map(|value| cef_sys::cef_string_userfree_wide_free(value));
+                        .map(|value| cef_dll_sys::cef_string_userfree_wide_free(value));
                 }
                 CefStringData::Clear(value) => {
-                    cef_sys::cef_string_wide_clear(value);
+                    cef_dll_sys::cef_string_wide_clear(value);
                 }
                 _ => {}
             }
@@ -393,7 +393,7 @@ impl From<&CefStringUtf8> for CefStringWide {
                 let value: *const _cef_string_utf8_t = value.into();
                 if let Some((str_, length)) = value.as_ref().map(|value| (value.str_, value.length))
                 {
-                    cef_sys::cef_string_utf8_to_wide(str_, length, &mut cef_string);
+                    cef_dll_sys::cef_string_utf8_to_wide(str_, length, &mut cef_string);
                 }
                 cef_string
             }
@@ -410,7 +410,7 @@ impl From<&CefStringUtf16> for CefStringWide {
                 let value: *const _cef_string_utf16_t = value.into();
                 if let Some((str_, length)) = value.as_ref().map(|value| (value.str_, value.length))
                 {
-                    cef_sys::cef_string_utf16_to_wide(str_, length, &mut cef_string);
+                    cef_dll_sys::cef_string_utf16_to_wide(str_, length, &mut cef_string);
                 }
                 cef_string
             }
@@ -453,7 +453,7 @@ impl Drop for CefStringList {
         unsafe {
             self.0
                 .as_mut()
-                .map(|value| cef_sys::cef_string_list_free(value));
+                .map(|value| cef_dll_sys::cef_string_list_free(value));
         }
     }
 }
@@ -477,11 +477,11 @@ impl IntoIterator for CefStringList {
     fn into_iter(self) -> Self::IntoIter {
         let list = unsafe { self.0.as_mut() };
         list.map(|list| {
-            let count = unsafe { cef_sys::cef_string_list_size(list) };
+            let count = unsafe { cef_dll_sys::cef_string_list_size(list) };
             (0..count)
                 .filter_map(|i| unsafe {
                     let mut value = mem::zeroed();
-                    (cef_sys::cef_string_list_value(list, i, &mut value) > 0).then_some(value)
+                    (cef_dll_sys::cef_string_list_value(list, i, &mut value) > 0).then_some(value)
                 })
                 .map(|value| {
                     CefStringUtf8::from(&CefString::from(ptr::from_ref(&value))).to_string()
@@ -501,7 +501,7 @@ impl Drop for CefStringMap {
         unsafe {
             self.0
                 .as_mut()
-                .map(|value| cef_sys::cef_string_map_free(value));
+                .map(|value| cef_dll_sys::cef_string_map_free(value));
         }
     }
 }
@@ -525,13 +525,13 @@ impl IntoIterator for CefStringMap {
     fn into_iter(self) -> Self::IntoIter {
         let map = unsafe { self.0.as_mut() };
         map.map(|map| {
-            let count = unsafe { cef_sys::cef_string_map_size(map) };
+            let count = unsafe { cef_dll_sys::cef_string_map_size(map) };
             (0..count)
                 .filter_map(|i| unsafe {
                     let mut key = mem::zeroed();
                     let mut value = mem::zeroed();
-                    (cef_sys::cef_string_map_key(map, i, &mut key) > 0
-                        && cef_sys::cef_string_map_value(map, i, &mut value) > 0)
+                    (cef_dll_sys::cef_string_map_key(map, i, &mut key) > 0
+                        && cef_dll_sys::cef_string_map_value(map, i, &mut value) > 0)
                         .then_some((key, value))
                 })
                 .map(|(key, value)| {
@@ -555,7 +555,7 @@ impl Drop for CefStringMultimap {
         unsafe {
             self.0
                 .as_mut()
-                .map(|value| cef_sys::cef_string_multimap_free(value));
+                .map(|value| cef_dll_sys::cef_string_multimap_free(value));
         }
     }
 }

--- a/download-cef/Cargo.toml
+++ b/download-cef/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "download-cef"
+description = "Download and extract pre-built CEF (Chromium Embedded Framework) archives."
+version = "1.0.0"
+
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+
+[dependencies]
+serde.workspace = true
+thiserror.workspace = true
+
+bzip2 = "0.5"
+indicatif = "0.17"
+sha1_smol = "1.0"
+tar = "0.4"
+ureq = { version = "2.12", features = [ "json" ] }

--- a/download-cef/Cargo.toml
+++ b/download-cef/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "download-cef"
 description = "Download and extract pre-built CEF (Chromium Embedded Framework) archives."
-version = "1.0.0"
+version = "1.1.0"
 
 edition.workspace = true
 license.workspace = true

--- a/download-cef/src/lib.rs
+++ b/download-cef/src/lib.rs
@@ -1,0 +1,309 @@
+use bzip2::bufread::BzDecoder;
+use serde::Deserialize;
+use sha1_smol::Sha1;
+use std::{
+    fs::{self, File},
+    io::BufReader,
+    path::{Path, PathBuf},
+};
+
+#[macro_use]
+extern crate thiserror;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Unsupported target triplet: {0}")]
+    UnsupportedTarget(String),
+    #[error("HTTP request error: {0}")]
+    Request(#[from] ureq::Error),
+    #[error("Version not found: {0}")]
+    VersionNotFound(String),
+    #[error("Missing Content-Length header")]
+    MissingContentLength,
+    #[error("Invalid Content-Length header: {0}")]
+    InvalidContentLength(String),
+    #[error("File I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("Unexpected file size: downloaded {downloaded} expected {expected}")]
+    UnexpectedFileSize { downloaded: u64, expected: u64 },
+    #[error("Bad SHA1 file hash: {0}")]
+    CorruptedFile(String),
+    #[error("Invalid archive file path: {0}")]
+    InvalidArchiveFile(String),
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+const DOWNLOAD_TEMPLATE: &str = "{msg} {spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {bytes}/{total_bytes} ({eta})";
+
+pub const LINUX_TARGETS: &[&str] = &[
+    "x86_64-unknown-linux-gnu",
+    "i686-unknown-linux-gnu",
+    "arm-unknown-linux-gnueabi",
+    "aarch64-unknown-linux-gnu",
+];
+
+pub const MACOS_TARGETS: &[&str] = &["aarch64-apple-darwin", "x86_64-apple-darwin"];
+
+pub const WINDOWS_TARGETS: &[&str] = &[
+    "aarch64-pc-windows-msvc",
+    "x86_64-pc-windows-msvc",
+    "i686-pc-windows-msvc",
+];
+
+const URL: &str = "https://cef-builds.spotifycdn.com";
+
+#[derive(Deserialize)]
+struct CefIndex {
+    macosarm64: CefPlatform,
+    macosx64: CefPlatform,
+    windows32: CefPlatform,
+    windows64: CefPlatform,
+    windowsarm64: CefPlatform,
+    linux32: CefPlatform,
+    linux64: CefPlatform,
+    linuxarm: CefPlatform,
+    linuxarm64: CefPlatform,
+}
+
+impl CefIndex {
+    fn platform(&self, target: &str) -> Result<&CefPlatform> {
+        match target {
+            "aarch64-apple-darwin" => Ok(&self.macosarm64),
+            "x86_64-apple-darwin" => Ok(&self.macosx64),
+            "i686-pc-windows-msvc" => Ok(&self.windows32),
+            "x86_64-pc-windows-msvc" => Ok(&self.windows64),
+            "aarch64-pc-windows-msvc" => Ok(&self.windowsarm64),
+            "i686-unknown-linux-gnu" => Ok(&self.linux32),
+            "x86_64-unknown-linux-gnu" => Ok(&self.linux64),
+            "arm-unknown-linux-gnueabi" => Ok(&self.linuxarm),
+            "aarch64-unknown-linux-gnu" => Ok(&self.linuxarm64),
+            v => Err(Error::UnsupportedTarget(v.to_string())),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct CefPlatform {
+    versions: Vec<CefVersion>,
+}
+
+#[derive(Deserialize)]
+struct CefVersion {
+    channel: String,
+    cef_version: String,
+    files: Vec<CefFile>,
+}
+
+#[derive(Deserialize)]
+struct CefFile {
+    #[serde(rename = "type")]
+    file_type: String,
+    name: String,
+    sha1: String,
+}
+
+pub fn download_target_archive<P>(
+    target: &str,
+    cef_version: &str,
+    location: P,
+    show_progress: bool,
+) -> Result<PathBuf>
+where
+    P: AsRef<Path>,
+{
+    if show_progress {
+        println!("Downloading CEF archive for {target}...");
+    }
+
+    let index: CefIndex = ureq::get(&format!("{URL}/index.json"))
+        .call()?
+        .into_json()?;
+    let platform = index.platform(target)?;
+    let version_prefix = format!("{cef_version}+");
+
+    let (file, sha) = platform
+        .versions
+        .iter()
+        .find_map(|v| {
+            if v.channel == "stable" && v.cef_version.starts_with(&version_prefix) {
+                v.files.iter().find_map(|f| {
+                    if f.file_type == "minimal" {
+                        Some((f.name.as_str(), f.sha1.as_str()))
+                    } else {
+                        None
+                    }
+                })
+            } else {
+                None
+            }
+        })
+        .ok_or_else(|| Error::VersionNotFound(cef_version.to_string()))?;
+
+    fs::create_dir_all(&location)?;
+    let download_file = location.as_ref().join(file);
+
+    if download_file.exists() {
+        if calculate_file_sha1(&download_file) == sha {
+            if show_progress {
+                println!("Verified archive: {}", download_file.display());
+            }
+            return Ok(download_file);
+        }
+
+        if show_progress {
+            println!("Cleaning corrupted archive: {}", download_file.display());
+        }
+        let corrupted_file = location.as_ref().join(format!("corrupted_{file}"));
+        fs::rename(&download_file, &corrupted_file)?;
+        fs::remove_file(&corrupted_file)?;
+    }
+
+    let cef_url = format!("{URL}/{file}");
+    if show_progress {
+        println!("Using archive url: {cef_url}");
+    }
+
+    let mut file = File::create(&download_file)?;
+
+    let resp = ureq::get(&cef_url).call()?;
+    let expected = resp
+        .header("Content-Length")
+        .ok_or(Error::MissingContentLength)?;
+    let expected = expected
+        .parse::<u64>()
+        .map_err(|_| Error::InvalidContentLength(expected.to_owned()))?;
+
+    let downloaded = if show_progress {
+        let bar = indicatif::ProgressBar::new(expected);
+        bar.set_style(
+            indicatif::ProgressStyle::with_template(DOWNLOAD_TEMPLATE)
+                .expect("invalid template")
+                .progress_chars("##-"),
+        );
+        bar.set_message("Downloading");
+        std::io::copy(&mut bar.wrap_read(resp.into_reader()), &mut file)
+    } else {
+        let mut reader = resp.into_reader();
+        std::io::copy(&mut reader, &mut file)
+    }?;
+
+    if downloaded != expected {
+        return Err(Error::UnexpectedFileSize {
+            downloaded,
+            expected,
+        });
+    }
+
+    if show_progress {
+        println!("Verifying SHA1 hash: {sha}...");
+    }
+    if calculate_file_sha1(&download_file) != sha {
+        return Err(Error::CorruptedFile(download_file.display().to_string()));
+    }
+
+    if show_progress {
+        println!("Downloaded archive: {}", download_file.display());
+    }
+    Ok(download_file)
+}
+
+pub fn extract_target_archive<P, Q>(
+    target: &str,
+    archive: P,
+    location: Q,
+    show_progress: bool,
+) -> Result<PathBuf>
+where
+    P: AsRef<Path>,
+    Q: AsRef<Path>,
+{
+    if show_progress {
+        println!("Extracting archive: {}", archive.as_ref().display());
+    }
+    let decoder = BzDecoder::new(BufReader::new(File::open(&archive)?));
+    tar::Archive::new(decoder).unpack(&location)?;
+
+    let extracted_dir = archive.as_ref().display().to_string();
+    let extracted_dir = extracted_dir
+        .strip_suffix(".tar.bz2")
+        .map(PathBuf::from)
+        .ok_or(Error::InvalidArchiveFile(extracted_dir))?;
+
+    let (os, arch) = target_to_os_arch(target)?;
+    let cef_dir = location.as_ref().join(format!("cef_{os}_{arch}"));
+
+    if cef_dir.exists() {
+        let old_dir = location.as_ref().join(format!("old_{os}_{arch}"));
+        if show_progress {
+            println!("Cleaning up: {}", old_dir.display());
+        }
+        fs::rename(&cef_dir, &old_dir)?;
+        fs::remove_dir_all(old_dir)?;
+    }
+    let release_dir = extracted_dir.join("Release");
+    fs::rename(&release_dir, &cef_dir)?;
+
+    if os != "macos" {
+        let resources = extracted_dir.join("Resources");
+
+        for entry in fs::read_dir(&resources)? {
+            let entry = entry?;
+            fs::rename(entry.path(), cef_dir.join(entry.file_name()))?;
+        }
+    }
+
+    let include_dir = extracted_dir.join("include");
+    fs::rename(&include_dir, cef_dir.join("include"))?;
+    let libcef_dll_dir = extracted_dir.join("libcef_dll");
+    fs::rename(&libcef_dll_dir, cef_dir.join("libcef_dll"))?;
+
+    if show_progress {
+        println!("Moved contents to: {}", cef_dir.display());
+    }
+
+    // Cleanup whatever is left in the extracted directory.
+    let old_dir = extracted_dir
+        .parent()
+        .map(|parent| parent.join(format!("extracted_{os}_{arch}")))
+        .ok_or_else(|| Error::InvalidArchiveFile(extracted_dir.display().to_string()))?;
+    if show_progress {
+        println!("Cleaning up: {}", old_dir.display());
+    }
+    fs::rename(&extracted_dir, &old_dir)?;
+    fs::remove_dir_all(old_dir)?;
+
+    Ok(cef_dir)
+}
+
+fn calculate_file_sha1(path: &Path) -> String {
+    use std::io::Read;
+    let mut file = BufReader::new(File::open(path).unwrap());
+    let mut sha1 = Sha1::new();
+    let mut buffer = [0; 8192];
+
+    loop {
+        let count = file.read(&mut buffer).unwrap();
+        if count == 0 {
+            break;
+        }
+        sha1.update(&buffer[..count]);
+    }
+
+    sha1.digest().to_string()
+}
+
+fn target_to_os_arch(target: &str) -> Result<(&str, &str)> {
+    match target {
+        "aarch64-apple-darwin" => Ok(("macos", "aarch64")),
+        "x86_64-apple-darwin" => Ok(("macos", "x86_64")),
+        "i686-pc-windows-msvc" => Ok(("windows", "x86")),
+        "x86_64-pc-windows-msvc" => Ok(("windows", "x86_64")),
+        "aarch64-pc-windows-msvc" => Ok(("windows", "aarch64")),
+        "x86_64-unknown-linux-gnu" => Ok(("linux", "x86_64")),
+        "i686-unknown-linux-gnu" => Ok(("linux", "x86")),
+        "arm-unknown-linux-gnueabi" => Ok(("linux", "arm")),
+        "aarch64-unknown-linux-gnu" => Ok(("linux", "aarch64")),
+        v => Err(Error::UnsupportedTarget(v.to_string())),
+    }
+}

--- a/sys/Cargo.toml
+++ b/sys/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
-name = "libcef-sys"
+name = "cef-dll-sys"
 description = "cef-rs sys crate"
+links = "cef_dll_wrapper"
 
 version.workspace = true
 edition.workspace = true
@@ -9,7 +10,6 @@ authors.workspace = true
 repository.workspace = true
 
 [lib]
-name = "cef_sys"
 doctest = false
 
 [features]
@@ -18,5 +18,7 @@ dox = []
 [package.metadata.docs.rs]
 features = [ "dox" ]
 
-[dev-dependencies]
-winit.workspace = true
+[build-dependencies]
+anyhow.workspace = true
+cmake.workspace = true
+download-cef.workspace = true

--- a/update-bindings/Cargo.toml
+++ b/update-bindings/Cargo.toml
@@ -9,17 +9,13 @@ authors.workspace = true
 repository.workspace = true
 
 [dependencies]
+download-cef.workspace = true
+thiserror.workspace = true
+
 bindgen = "0.71"
-bzip2 = "0.5"
 clap = { version = "4.5", features = [ "derive" ] }
 convert_case = "0.7"
-indicatif = "0.17"
 proc-macro2 = "1.0"
 quote = "1.0"
 regex = "1.0"
-serde_json = "1.0"
-sha1_smol = "1"
 syn = { version = "2.0", features = [ "full" ] }
-tar = "0.4"
-thiserror = "2.0"
-ureq = { version = "2.12", features = [ "json" ] }

--- a/update-bindings/Cargo.toml
+++ b/update-bindings/Cargo.toml
@@ -10,12 +10,12 @@ repository.workspace = true
 
 [dependencies]
 download-cef.workspace = true
-thiserror.workspace = true
 
-bindgen = "0.71"
-clap = { version = "4.5", features = [ "derive" ] }
-convert_case = "0.7"
-proc-macro2 = "1.0"
-quote = "1.0"
-regex = "1.0"
-syn = { version = "2.0", features = [ "full" ] }
+bindgen.workspace = true
+clap.workspace = true
+convert_case.workspace = true
+proc-macro2.workspace = true
+quote.workspace = true
+regex.workspace = true
+syn.workspace = true
+thiserror.workspace = true

--- a/update-bindings/src/main.rs
+++ b/update-bindings/src/main.rs
@@ -65,10 +65,7 @@ fn main() -> Result<()> {
 
     if args.bindgen {
         if args.download {
-            let archive_dir = upgrade::download(target);
-            if archive_dir.exists() {
-                fs::remove_dir_all(archive_dir).unwrap();
-            }
+            let _ = upgrade::download(target);
         }
 
         upgrade::sys_bindgen(target)?;

--- a/update-bindings/src/parse_tree.rs
+++ b/update-bindings/src/parse_tree.rs
@@ -1531,7 +1531,7 @@ impl<'a> ParseTree<'a> {
             use crate::rc::{
                 ConvertParam, ConvertReturnValue, Rc, RcImpl, RefGuard, WrapParamRef,
             };
-            use cef_sys::*;
+            use cef_dll_sys::*;
         }
         .to_string();
         writeln!(f, "{header}")?;

--- a/update-bindings/src/upgrade.rs
+++ b/update-bindings/src/upgrade.rs
@@ -1,12 +1,9 @@
 use crate::dirs;
 use std::{
-    env,
-    fs::{self, File},
+    env, fs,
     path::{Path, PathBuf},
     process::Command,
 };
-
-const DOWNLOAD_TEMPLATE: &str = "{msg} {spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {bytes}/{total_bytes} ({eta})";
 
 const TARGETS: &[&str] = &[
     // macos
@@ -23,14 +20,34 @@ const TARGETS: &[&str] = &[
     "aarch64-unknown-linux-gnu",
 ];
 
-const URL: &str = "https://cef-builds.spotifycdn.com";
-
 pub fn download(target: &str) -> PathBuf {
     assert!(TARGETS.contains(&target), "unsupported target {target}");
     let (os, arch) = target_to_os_arch(target);
     let cef_path = dirs::get_cef_root(os, arch);
-    let archive_dir = download_prebuilt_cef(target, &cef_path);
+
+    let archive = download_cef::download_target_archive(
+        target,
+        env!("CARGO_PKG_VERSION"),
+        dirs::get_out_dir(),
+        true,
+    )
+    .expect("download failed");
+    let archive_dir =
+        download_cef::extract_target_archive(target, &archive, dirs::get_out_dir(), true)
+            .expect("extraction failed");
+
     build_cef_dll_wrapper(&cef_path, &archive_dir, os);
+
+    // rename cef_sandbox.a to libcef_sandbox.a, since we cannot link the library without lib
+    // prefix, see https://www.reddit.com/r/rust/comments/dzj650/linking_against_lib_which_file_name_doesnt_start
+    if os == "macos" {
+        fs::rename(
+            cef_path.join("cef_sandbox.a"),
+            cef_path.join("libcef_sandbox.a"),
+        )
+        .expect("failed to rename cef_sandbox.a");
+    }
+
     archive_dir
 }
 
@@ -44,135 +61,6 @@ pub fn sys_bindgen(target: &str) -> crate::Result<()> {
 pub fn get_target_bindings(target: &str) -> String {
     assert!(TARGETS.contains(&target), "unsupported target {target}");
     format!("{}.rs", target.replace('-', "_"))
-}
-
-fn download_prebuilt_cef(target: &str, cef_path: &Path) -> PathBuf {
-    println!("cef: trying to download {target}");
-
-    let url = env::var("CEF_URL").unwrap_or_else(|_| URL.to_string());
-    let platform = target_to_cef_target(target);
-    let index: serde_json::Value = ureq::get(&format!("{url}/index.json"))
-        .call()
-        .unwrap()
-        .into_json()
-        .unwrap();
-
-    let (file, sha) = index[platform]["versions"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .find_map(|v| {
-            let channel = v["channel"].as_str()?;
-            let cef_version = v["cef_version"].as_str()?;
-            if channel == "stable"
-                && cef_version.starts_with(concat!(env!("CARGO_PKG_VERSION"), "+"))
-            {
-                v["files"].as_array().unwrap().iter().find_map(|f| {
-                    if f["type"].as_str() == Some("minimal") {
-                        Some((f["name"].as_str().unwrap(), f["sha1"].as_str().unwrap()))
-                    } else {
-                        None
-                    }
-                })
-            } else {
-                None
-            }
-        })
-        .expect("Matching CEF version not found");
-
-    let cef_url = format!("{url}/{file}");
-    println!("cef: downloading url {cef_url}");
-
-    let download = cef_path.parent().unwrap();
-    fs::create_dir_all(download).unwrap();
-    let download_file = download.join(file);
-
-    if !download_file.exists() || calculate_file_sha1(&download_file) != sha {
-        download_file_with_progress(&cef_url, &download_file);
-    }
-
-    assert_eq!(calculate_file_sha1(&download_file), sha, "sha1sum mismatch");
-    println!("cef: downloaded into {}", download_file.display());
-
-    extract_and_organize(download, file, &download_file, target, cef_path)
-}
-
-fn download_file_with_progress(url: &str, path: &Path) {
-    let mut file = File::create(path).unwrap();
-    let resp = ureq::get(url).call().unwrap();
-    let length: u64 = resp.header("Content-Length").unwrap().parse().unwrap();
-
-    let bar = indicatif::ProgressBar::new(length);
-    bar.set_style(
-        indicatif::ProgressStyle::with_template(DOWNLOAD_TEMPLATE)
-            .unwrap()
-            .progress_chars("##-"),
-    );
-    bar.set_message("Downloading");
-
-    std::io::copy(&mut bar.wrap_read(resp.into_reader()), &mut file).unwrap();
-}
-
-fn extract_and_organize(
-    download_path: &Path,
-    file_name: &str,
-    download_file: &Path,
-    target: &str,
-    cef_path: &Path,
-) -> PathBuf {
-    let decoder =
-        bzip2::bufread::BzDecoder::new(std::io::BufReader::new(File::open(download_file).unwrap()));
-    tar::Archive::new(decoder).unpack(download_path).unwrap();
-
-    let extracted_dir = download_path.join(file_name.strip_suffix(".tar.bz2").unwrap());
-    let (os, arch) = target_to_os_arch(target);
-    let archive_dir = download_path.join(format!("archive_{os}_{arch}"));
-
-    if archive_dir.exists() {
-        fs::remove_dir_all(&archive_dir).unwrap();
-    }
-    fs::rename(extracted_dir, &archive_dir).unwrap();
-
-    if cef_path.exists() {
-        fs::remove_dir_all(cef_path).unwrap();
-    }
-    fs::rename(archive_dir.join("Release"), cef_path).unwrap();
-
-    if os != "macos" {
-        copy_directory(&archive_dir.join("Resources"), cef_path);
-    }
-
-    copy_directory(&archive_dir.join("include"), &cef_path.join("include"));
-
-    // rename cef_sandbox.a to libcef_sandbox.a, since we cannot link the library without lib
-    // prefix, see https://www.reddit.com/r/rust/comments/dzj650/linking_against_lib_which_file_name_doesnt_start
-    if matches!(os, "macos") {
-        std::fs::copy(
-            cef_path.join("cef_sandbox.a"),
-            cef_path.join("libcef_sandbox.a"),
-        )
-        .unwrap();
-    }
-
-    println!("cef: extracted into CEF_PATH={:?}", cef_path);
-    archive_dir
-}
-
-fn calculate_file_sha1(path: &Path) -> String {
-    use std::io::Read;
-    let mut file = std::io::BufReader::new(File::open(path).unwrap());
-    let mut sha1 = sha1_smol::Sha1::new();
-    let mut buffer = [0; 8192];
-
-    loop {
-        let count = file.read(&mut buffer).unwrap();
-        if count == 0 {
-            break;
-        }
-        sha1.update(&buffer[..count]);
-    }
-
-    sha1.digest().to_string()
 }
 
 fn bindgen(target: &str, cef_path: &Path) -> crate::Result<()> {
@@ -257,36 +145,6 @@ fn build_cef_dll_wrapper(cef_path: &Path, archive_dir: &Path, os: &str) {
         cef_path.join(&lib_name),
     )
     .unwrap();
-}
-
-fn copy_directory(src: &Path, dst: &Path) {
-    fs::create_dir_all(dst).unwrap();
-    for entry in fs::read_dir(src).unwrap() {
-        let entry = entry.unwrap();
-        let src_path = entry.path();
-        let dst_path = dst.join(entry.file_name());
-
-        if entry.file_type().unwrap().is_dir() {
-            copy_directory(&src_path, &dst_path);
-        } else {
-            fs::copy(&src_path, &dst_path).unwrap();
-        }
-    }
-}
-
-fn target_to_cef_target(target: &str) -> &str {
-    match target {
-        "aarch64-apple-darwin" => "macosarm64",
-        "x86_64-apple-darwin" => "macosx64",
-        "i686-pc-windows-msvc" => "windows32",
-        "x86_64-pc-windows-msvc" => "windows64",
-        "aarch64-pc-windows-msvc" => "windowsarm64",
-        "i686-unknown-linux-gnu" => "linux32",
-        "x86_64-unknown-linux-gnu" => "linux64",
-        "arm-unknown-linux-gnueabi" => "linuxarm",
-        "aarch64-unknown-linux-gnu" => "linuxarm64",
-        v => panic!("unsupported {v:?}"),
-    }
 }
 
 fn target_to_os_arch(target: &str) -> (&str, &str) {


### PR DESCRIPTION
I went ahead and published this version of `download-cef` and `cef-dll-sys` already to claim the crate names.