### PR TITLE
fix: replace crate doc header to unblock publish

### DIFF
--- a/cef/src/lib.rs
+++ b/cef/src/lib.rs
@@ -1,5 +1,5 @@
 //! # cef-rs
-//! 
+//!
 //! Use the [Chromium Embedded Framework](https://github.com/chromiumembedded/cef) in Rust.
 
 pub mod args;

--- a/cef/src/lib.rs
+++ b/cef/src/lib.rs
@@ -1,4 +1,6 @@
-#![doc = include_str!("../../README.md")]
+//! # cef-rs
+//! 
+//! Use the [Chromium Embedded Framework](https://github.com/chromiumembedded/cef) in Rust.
 
 pub mod args;
 pub mod rc;


### PR DESCRIPTION
The `cargo publish` command fails with the `include!(../../README.md)`  trick, it doesn't like referencing anything outside of the crate directory since it's not part of the package that's uploaded to crates.io.