### PR TITLE
improvement(download-cef): use libbz2 rust drop-in replacement

### DIFF
--- a/download-cef/Cargo.toml
+++ b/download-cef/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 
-bzip2 = "0.5"
+bzip2 = { version = "0.5", default-features = false, features = ["libbz2-rs-sys"] }
 indicatif = "0.17"
 sha1_smol = "1"
 tar = "0.4"


### PR DESCRIPTION
This allows developer to build their project with one less dependency to externally manage