### PR TITLE
chore: bump CEF version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,7 @@ dependencies = [
 
 [[package]]
 name = "cef"
-version = "132.3.1"
+version = "132.3.2"
 dependencies = [
  "cef-dll-sys",
  "windows-sys 0.59.0",
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "cef-dll-sys"
-version = "132.3.1"
+version = "132.3.2"
 dependencies = [
  "anyhow",
  "cmake",
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "export-cef-dir"
-version = "132.3.1"
+version = "132.3.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1134,7 +1134,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "update-bindings"
-version = "132.3.1"
+version = "132.3.2"
 dependencies = [
  "bindgen",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "132.3.1"
+version = "132.3.2"
 edition = "2021"
 license = "Apache-2.0 OR MIT"
 authors = [
@@ -21,7 +21,7 @@ authors = [
 repository = "https://github.com/tauri-apps/cef-rs"
 
 [workspace.dependencies]
-cef-dll-sys = { version = "132.3.1", path = "sys" }
+cef-dll-sys = { version = "132.3.2", path = "sys" }
 download-cef = { version = "1.2", path = "download-cef" }
 
 anyhow = "1"


### PR DESCRIPTION
This didn't have any effect on the bindings that were generated.