### PR TITLE
export-cef-dir supports macOS x86_64 architecture

### DIFF
--- a/export-cef-dir/src/main.rs
+++ b/export-cef-dir/src/main.rs
@@ -11,7 +11,11 @@ use std::{
 #[cfg(target_os = "windows")]
 const DEFAULT_TARGET: &str = "x86_64-pc-windows-msvc";
 #[cfg(target_os = "macos")]
+#[cfg(target_arch = "aarch64")]
 const DEFAULT_TARGET: &str = "aarch64-apple-darwin";
+#[cfg(target_os = "macos")]
+#[cfg(target_arch = "x86_64")]
+const DEFAULT_TARGET: &str = "x86_64-apple-darwin";
 #[cfg(target_os = "linux")]
 const DEFAULT_TARGET: &str = "x86_64-unknown-linux-gnu";
 


### PR DESCRIPTION
Compiled on a Mac with an Intel architecture is an ARM architecture build of CEF. Support is needed, and the error is as follows:

> warning: `cef-dll-sys` (build script) generated 1 warning
> 
>    Compiling cef v134.3.7 (/Users/longwei/cef-rs/cef)
> 
> error: linking with `cc` failed: exit status: 1
> 
>   |
> 
>   = note: env -u IPHONEOS_DEPLOYMENT_TARGET -u TVOS_DEPLOYMENT_TARGET -u XROS_DEPLOYMENT_TARGET LC_ALL="C" PATH="/Users/longwei/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/bin:/Users/longwei/.nvm/versions/node/v16.20.1/bin:/Users/longwei/.wasmtime/bin:/Users/longwei/.wasmer/bin:/Users/longwei/.nvm/versions/node/v16.20.1/bin:/Library/Frameworks/Python.framework/Versions/3.13/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/X11/bin:/Library/Apple/usr/bin:/usr/local/go/bin:/Users/longwei/.wasmtime/bin:/Users/longwei/.wasmer/bin:/Users/longwei/.nvm/versions/node/v16.20.1/bin:/Library/Frameworks/Python.framework/Versions/3.13/bin:/Users/longwei/.cargo/bin:/Users/longwei/.orbstack/bin:/Users/longwei/npm/bin:/Users/longwei/Library/Android/sdk/platform-tools:/Users/longwei/flutter/sdk/bin:/Users/longwei/.wasmer/globals/wapm_packages/.bin:/Users/longwei/.orbstack/bin:/Users/longwei/npm/bin:/Users/longwei/Library/Android/sdk/platform-tools:/Users/longwei/flutter/sdk/bin:/Users/longwei/.wasmer/globals/wapm_packages/.bin" VSLANG="1033" ZERO_AR_DATE="1" "cc" "/var/folders/jl/bx1zz24x1gldn0px8989bnxw0000gn/T/rustcwxrLIT/symbols.o" "<12 object files omitted>" "/Users/longwei/cef-rs/target/debug/deps/{libcef-07a712d5f81994d8.rlib,libcef_dll_sys-83f0bc1e40be09c2.rlib}" "/Users/longwei/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/{libstd-d40ed3d85bccd72d.rlib,libpanic_unwind-2cf5a2ac30651b89.rlib,libobject-34a80b1d917c2ecb.rlib,libmemchr-9de36d79ed942e4f.rlib,libaddr2line-0956759e786437fb.rlib,libgimli-ca13b3dc542bcfd8.rlib,librustc_demangle-e93b983abdee7535.rlib,libstd_detect-dbdde1496ad160bb.rlib,libhashbrown-b06b8c78fdb897d1.rlib,librustc_std_workspace_alloc-390432d1d1ccde95.rlib,libminiz_oxide-a3b5659b5c372285.rlib,libadler2-a99e7af29feab77f.rlib,libunwind-c7254755f0220c9a.rlib,libcfg_if-b02e4c736bc02b6e.rlib,liblibc-5f8e14d88f8e7cb9.rlib,liballoc-6f32ce40c1e897e7.rlib,librustc_std_workspace_core-fa94e51c9ca90d9e.rlib,libcore-3ec3767b96552076.rlib,libcompiler_builtins-549c4fb5bb90c2f8.rlib}" "-framework" "AppKit" "-lsandbox" "-lSystem" "-lc" "-lm" "-arch" "x86_64" "-mmacosx-version-min=10.12.0" "-L" "/Users/longwei/.local/share/cef" "-L" "/Users/longwei/cef-rs/target/debug/build/cef-dll-sys-aa635f216a653f37/out/build/libcef_dll_wrapper" "-o" "/Users/longwei/cef-rs/target/debug/examples/cefsimple_helper-a4660e98845161eb" "-Wl,-dead_strip" "-nodefaultlibs"
> 
>   = note: some arguments are omitted. use `--verbose` to show all linker arguments
> 
>   = note: ld: warning: ignoring file '/Users/longwei/cef-rs/target/debug/deps/libcef_dll_sys-83f0bc1e40be09c2.rlib[241](cef_sandbox.o)': found architecture 'arm64', required architecture 'x86_64'
> 
>           ld: warning: object file (/Users/longwei/cef-rs/target/debug/deps/libcef_dll_sys-83f0bc1e40be09c2.rlib[240](libcef_dll_dylib.cc.o)) was built for newer 'macOS' version (11.0) than being linked (10.12)
> 
>           Undefined symbols for architecture x86_64:
> 
>             "_cef_sandbox_destroy", referenced from:
> 
>                 cef::bindings::x86_64_apple_darwin::sandbox_destroy::h13d0fd6e870d7cae in libcef-07a712d5f81994d8.rlib[12](cef-07a712d5f81994d8.2txgm39or76z5r1c8iyj49wyy.rcgu.o)
> 
>             "_cef_sandbox_initialize", referenced from:
> 
>                 cef::bindings::x86_64_apple_darwin::sandbox_initialize::hc84b47e50bc4701a in libcef-07a712d5f81994d8.rlib[12](cef-07a712d5f81994d8.2txgm39or76z5r1c8iyj49wyy.rcgu.o)
> 
>           ld: symbol(s) not found for architecture x86_64
> 
>           clang: error: linker command failed with exit code 1 (use -v to see invocation)
> 
>           
> 
> 
> 
> error: could not compile `cef` (example "cefsimple_helper") due to 1 previous error