### PR TITLE
fix: build libcef_dll_wrapper with target arch

### DIFF
--- a/sys/build.rs
+++ b/sys/build.rs
@@ -65,6 +65,11 @@ fn main() -> anyhow::Result<()> {
         .profile("RelWithDebInfo")
         .no_build_target(true);
 
+    let project_arch = match os_arch.arch {
+        "aarch64" => "arm64",
+        arch => arch,
+    };
+
     match os_arch.os {
         "linux" => {
             println!("cargo::rustc-link-lib=dylib=cef");
@@ -92,6 +97,7 @@ fn main() -> anyhow::Result<()> {
                 .define("CMAKE_MSVC_RUNTIME_LIBRARY", "MultiThreaded")
                 .define("CMAKE_OBJECT_PATH_MAX", "500")
                 .define("CMAKE_STATIC_LINKER_FLAGS", &sdk_libs)
+                .define("PROJECT_ARCH", project_arch)
                 .build()
                 .display()
                 .to_string();
@@ -108,6 +114,7 @@ fn main() -> anyhow::Result<()> {
 
             let build_dir = cef_dll_wrapper
                 .no_default_flags(true)
+                .define("PROJECT_ARCH", project_arch)
                 .build()
                 .display()
                 .to_string();


### PR DESCRIPTION
Cross compiling for x86_64 does not work on my arm64 mac because `libcef_dll_wrapper` is built with the wrong architecture:

```
$ rustup target add x86_64-apple-darwin
$ cargo build -p cef-dll-sys --target x86_64-apple-darwin

$ lipo -info ./target/x86_64-apple-darwin/debug/build/cef-dll-sys-f52b2fa789d9b239/out/build/libcef_dll_wrapper/libcef_dll_wrapper.a
Non-fat file: libcef_dll_wrapper.a is architecture: arm64
```

This is because [CEF's cmake configuration](https://github.com/chromiumembedded/cef/blob/7581264dbb9a2a38bd7d6635d011050dc695b88f/cmake/cef_variables.cmake.in#L27-L37) uses `CMAKE_HOST_SYSTEM_PROCESSOR` to determine architecture, unless a `PROJECT_ARCH` variable is defined.