### PR TITLE
Only build target libcef_dll_wrapper

### DIFF
--- a/sys/build.rs
+++ b/sys/build.rs
@@ -63,7 +63,7 @@ fn main() -> anyhow::Result<()> {
     cef_dll_wrapper
         .generator("Ninja")
         .profile("RelWithDebInfo")
-        .no_build_target(true);
+        .build_target("libcef_dll_wrapper");
 
     let project_arch = match os_arch.arch {
         "aarch64" => "arm64",


### PR DESCRIPTION
Remove `cefclient/cefsimple/tests` buildings, should save some compilation time.