### PR TITLE
feat: Download-cef supports proxy environment variables.

### DIFF
--- a/download-cef/Cargo.toml
+++ b/download-cef/Cargo.toml
@@ -19,4 +19,4 @@ bzip2 = { version = "0.5", default-features = false, features = [
 indicatif = "0.17"
 sha1_smol = "1"
 tar = "0.4"
-ureq = { version = "3", features = ["json"] }
+ureq = { version = "3", features = ["json", "socks-proxy"] }


### PR DESCRIPTION
The current project doesn't have the "socks-proxy" feature enabled when importing ureq. This causes the proxy not to work when downloading CEF, even if proxy environment variables are set, leading to an error. This commit fixes this issue.

> cargo run -p export-cef-dir -- --force $HOME/.local/share/cef
> 
>     Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.35s
> 
>      Running `target/debug/export-cef-dir --force /Users/longwei/.local/share/cef`
> 
> Error: HTTP request error: io: Connection refused
> 
> 
> 
> Caused by:
> 
>     io: Connection refused