### PR TITLE
Implement cef offscreen rendering with wgpu and winit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "export-cef-dir",
     "sys",
     "cef",
+    "cef/examples/osr",
 ]
 
 [workspace.package]

--- a/cef/examples/osr/Cargo.toml
+++ b/cef/examples/osr/Cargo.toml
@@ -10,4 +10,8 @@ wgpu = "25"
 tokio = { version = "1", features = ["full"] }
 cef = { path = "../../" }
 winit = { version = "0.30" }
-windows = "0"
+windows = { version = "0.58", features = ["Win32_Graphics_Direct3D12"] }
+bytemuck = "*"
+
+# For gpu debugging on Windows with PIX
+libloading = "0.8"

--- a/cef/examples/osr/Cargo.toml
+++ b/cef/examples/osr/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "cef-osr"
+edition = "2024"
+publish = false
+
+[dependencies]
+env_logger = "0.11"
+pollster = "0.4"
+wgpu = "25"
+tokio = { version = "1", features = ["full"] }
+cef = { path = "../../" }
+winit = { version = "0.30" }
+windows = "0"

--- a/cef/examples/osr/src/main.rs
+++ b/cef/examples/osr/src/main.rs
@@ -1,0 +1,299 @@
+mod webrender;
+use cef::{args::Args, *};
+use std::{process::ExitCode, sync::Arc, thread::sleep, time::Duration};
+use tokio::runtime::Runtime;
+use wgpu::Backends;
+use winit::{
+    application::ApplicationHandler,
+    event::WindowEvent,
+    event_loop::{ActiveEventLoop, ControlFlow, EventLoop},
+    platform::pump_events::{EventLoopExtPumpEvents, PumpStatus},
+    window::{Window, WindowId},
+};
+
+use crate::webrender::{
+    ClientBuilder, OsrApp, OsrRenderHandler, OsrRequestContextHandler, RequestContextHandlerBuilder,
+};
+
+struct State {
+    window: Arc<Window>,
+    device: wgpu::Device,
+    queue: wgpu::Queue,
+    size: winit::dpi::PhysicalSize<u32>,
+    surface: wgpu::Surface<'static>,
+    surface_format: wgpu::TextureFormat,
+}
+
+impl State {
+    async fn new(window: Arc<Window>) -> State {
+        let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
+            backends: Backends::from_comma_list("dx12"),
+            ..Default::default()
+        });
+        let adapter = instance
+            .request_adapter(&wgpu::RequestAdapterOptions {
+                force_fallback_adapter: false,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        let (device, queue) = adapter
+            .request_device(&wgpu::DeviceDescriptor::default())
+            .await
+            .unwrap();
+
+        let size = window.inner_size();
+
+        let surface = instance.create_surface(window.clone()).unwrap();
+        let cap = surface.get_capabilities(&adapter);
+        let surface_format = cap.formats[0];
+
+        let state = State {
+            window,
+            device,
+            queue,
+            size,
+            surface,
+            surface_format,
+        };
+
+        // Configure surface for the first time
+        state.configure_surface();
+
+        state
+    }
+
+    fn get_window(&self) -> &Window {
+        &self.window
+    }
+
+    fn configure_surface(&self) {
+        let surface_config = wgpu::SurfaceConfiguration {
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            format: self.surface_format,
+            // Request compatibility with the sRGB-format texture view we‘re going to create later.
+            view_formats: vec![self.surface_format.add_srgb_suffix()],
+            alpha_mode: wgpu::CompositeAlphaMode::Auto,
+            width: self.size.width,
+            height: self.size.height,
+            desired_maximum_frame_latency: 2,
+            present_mode: wgpu::PresentMode::AutoVsync,
+        };
+        self.surface.configure(&self.device, &surface_config);
+    }
+
+    fn resize(&mut self, new_size: winit::dpi::PhysicalSize<u32>) {
+        self.size = new_size;
+
+        // reconfigure the surface
+        self.configure_surface();
+    }
+
+    fn render(&mut self) {
+        // Create texture view
+        let surface_texture = self
+            .surface
+            .get_current_texture()
+            .expect("failed to acquire next swapchain texture");
+        let mut texture1 = surface_texture.texture.clone();
+        webrender::TEXTURE.with_borrow(|t| {
+            if let Some(texture) = t {
+                texture1 = texture.clone();
+            }
+        });
+        let texture_view = texture1.create_view(&wgpu::TextureViewDescriptor {
+            // Without add_srgb_suffix() the image we will be working with
+            // might not be "gamma correct".
+            format: Some(self.surface_format.add_srgb_suffix()),
+            ..Default::default()
+        });
+
+        // Renders a GREEN screen
+        let mut encoder = self.device.create_command_encoder(&Default::default());
+        // Create the renderpass which will clear the screen.
+        let renderpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: None,
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: &texture_view,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(wgpu::Color::GREEN),
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+        });
+
+        // If you wanted to call any drawing commands, they would go here.
+
+        // End the renderpass.
+        drop(renderpass);
+
+        // Submit the command in the queue to execute
+        self.queue.submit([encoder.finish()]);
+        self.window.pre_present_notify();
+        surface_texture.present();
+    }
+}
+
+struct App {
+    state: Option<State>,
+    runtime: Runtime,
+    browser: Option<Browser>,
+}
+
+impl App {
+    fn new() -> Self {
+        App {
+            state: None,
+            runtime: tokio::runtime::Runtime::new().unwrap(),
+            browser: None,
+        }
+    }
+}
+
+impl ApplicationHandler for App {
+    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+        // Create window object
+        let window = Arc::new(
+            event_loop
+                .create_window(Window::default_attributes())
+                .unwrap(),
+        );
+
+        let state = pollster::block_on(State::new(window.clone()));
+        self.state = Some(state);
+        let mut window_info = WindowInfo::default();
+        window_info.windowless_rendering_enabled = true as _;
+        window_info.shared_texture_enabled = true as _;
+        let render_handler = OsrRenderHandler::new(
+            self.state.as_ref().unwrap().device.clone(),
+            window.scale_factor() as _,
+        );
+        let mut browser_settings = BrowserSettings::default();
+        browser_settings.windowless_frame_rate = 60;
+        let mut context = cef::request_context_create_context(
+            Some(&RequestContextSettings::default()),
+            Some(&mut RequestContextHandlerBuilder::build(
+                OsrRequestContextHandler {},
+            )),
+        );
+
+        let browser = cef::browser_host_create_browser_sync(
+            Some(&window_info),
+            Some(&mut ClientBuilder::build(render_handler)),
+            Some(&"https:://github.com".into()),
+            Some(&browser_settings),
+            None,
+            context.as_mut(),
+        );
+        assert!(browser.is_some());
+        self.browser = browser;
+
+        window.request_redraw();
+    }
+
+    fn window_event(&mut self, event_loop: &ActiveEventLoop, _id: WindowId, event: WindowEvent) {
+        let state = self.state.as_mut().unwrap();
+        match event {
+            WindowEvent::CloseRequested => {
+                println!("The close button was pressed; stopping");
+                event_loop.exit();
+            }
+            WindowEvent::RedrawRequested => {
+                state.render();
+                // Emits a new redraw requested event.
+                state.get_window().request_redraw();
+            }
+            WindowEvent::Resized(size) => {
+                // Reconfigures the size of the surface. We do not re-render
+                // here as this event is always followed up by redraw request.
+                state.resize(size);
+            }
+            _ => (),
+        }
+    }
+}
+
+fn main() -> std::process::ExitCode {
+    env_logger::init();
+
+    #[cfg(target_os = "macos")]
+    let _loader = {
+        let loader = library_loader::LibraryLoader::new(&std::env::current_exe().unwrap(), false);
+        assert!(loader.load());
+        loader
+    };
+
+    let _ = api_hash(sys::CEF_API_VERSION_LAST, 0);
+
+    let args = Args::new();
+    let cmd = args.as_cmd_line().unwrap();
+
+    let switch = CefString::from("type");
+    let is_browser_process = cmd.has_switch(Some(&switch)) != 1;
+    let mut app = webrender::AppBuilder::build(OsrApp::new());
+    let ret = execute_process(
+        Some(args.as_main_args()),
+        Some(&mut app),
+        std::ptr::null_mut(),
+    );
+
+    if is_browser_process {
+        println!("launch browser process");
+        assert!(ret == -1, "cannot execute browser process");
+    } else {
+        let process_type = CefString::from(&cmd.switch_value(Some(&switch)));
+        println!("launch process {process_type}");
+        assert!(ret >= 0, "cannot execute non-browser process");
+        // non-browser process does not initialize cef
+        return 0.into();
+    }
+    let mut settings = Settings::default();
+    settings.windowless_rendering_enabled = true as _;
+    settings.external_message_pump = true as _;
+    assert_eq!(
+        initialize(
+            Some(args.as_main_args()),
+            Some(&settings),
+            Some(&mut app),
+            std::ptr::null_mut(),
+        ),
+        1
+    );
+
+    let mut event_loop = EventLoop::new().unwrap();
+
+    // When the current loop iteration finishes, immediately begin a new
+    // iteration regardless of whether or not new events are available to
+    // process. Preferred for applications that want to render as fast as
+    // possible, like games.
+    event_loop.set_control_flow(ControlFlow::Poll);
+
+    // When the current loop iteration finishes, suspend the thread until
+    // another event arrives. Helps keeping CPU utilization low if nothing
+    // is happening, which is preferred if the application might be idling in
+    // the background.
+    // event_loop.set_control_flow(ControlFlow::Wait);
+
+    let mut app = App::new();
+    let ret = loop {
+        do_message_loop_work();
+        let timeout = Some(Duration::ZERO);
+        let status = event_loop.pump_app_events(timeout, &mut app);
+
+        if let PumpStatus::Exit(exit_code) = status {
+            break ExitCode::from(exit_code as u8);
+        }
+
+        // Sleep for 1/60 second to simulate application work
+        //
+        // Since `pump_events` doesn't block it will be important to
+        // throttle the loop in the app somehow.
+        sleep(Duration::from_millis(16));
+    };
+    cef::shutdown();
+    ret
+}

--- a/cef/examples/osr/src/main.rs
+++ b/cef/examples/osr/src/main.rs
@@ -1,38 +1,41 @@
 mod webrender;
 use cef::{args::Args, *};
-use std::{process::ExitCode, sync::Arc, thread::sleep, time::Duration};
-use tokio::runtime::Runtime;
+use std::{cell::RefCell, process::ExitCode, sync::Arc, thread::sleep, time::Duration};
 use wgpu::Backends;
+use wgpu::util::DeviceExt;
 use winit::{
     application::ApplicationHandler,
     event::WindowEvent,
     event_loop::{ActiveEventLoop, ControlFlow, EventLoop},
     platform::pump_events::{EventLoopExtPumpEvents, PumpStatus},
-    window::{Window, WindowId},
+    window::{Window, WindowAttributes, WindowId},
 };
 
 use crate::webrender::{
-    ClientBuilder, OsrApp, OsrRenderHandler, OsrRequestContextHandler, RequestContextHandlerBuilder,
+    ClientBuilder, OsrApp, OsrRenderHandler, OsrRequestContextHandler,
+    RequestContextHandlerBuilder, TEXTURE,
 };
 
 struct State {
     window: Arc<Window>,
     device: wgpu::Device,
+    pipeline: wgpu::RenderPipeline,
     queue: wgpu::Queue,
     size: winit::dpi::PhysicalSize<u32>,
     surface: wgpu::Surface<'static>,
     surface_format: wgpu::TextureFormat,
+    quad: Geometry,
 }
 
 impl State {
     async fn new(window: Arc<Window>) -> State {
         let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
             backends: Backends::from_comma_list("dx12"),
+            //flags: wgpu::InstanceFlags::debugging(),
             ..Default::default()
         });
         let adapter = instance
             .request_adapter(&wgpu::RequestAdapterOptions {
-                force_fallback_adapter: false,
                 ..Default::default()
             })
             .await
@@ -45,19 +48,93 @@ impl State {
         let size = window.inner_size();
 
         let surface = instance.create_surface(window.clone()).unwrap();
-        let cap = surface.get_capabilities(&adapter);
-        let surface_format = cap.formats[0];
+        let surface_format = wgpu::TextureFormat::Bgra8Unorm;
+        let texture_bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("Cef Texture Bind Group Layout"),
+                entries: &[
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Texture {
+                            multisampled: false,
+                            view_dimension: wgpu::TextureViewDimension::D2,
+                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        },
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 1,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                        count: None,
+                    },
+                ],
+            });
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("Cef Shader"),
+            source: wgpu::ShaderSource::Wgsl(include_str!("shader.wgsl").into()),
+        });
+
+        let render_pipeline_layout =
+            device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("Cef Pipeline Layout"),
+                bind_group_layouts: &[&texture_bind_group_layout],
+                push_constant_ranges: &[],
+            });
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("Cef Render Pipeline"),
+            layout: Some(&render_pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                buffers: &[Vertex::desc()],
+                compilation_options: Default::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: wgpu::TextureFormat::Bgra8Unorm,
+                    blend: Some(wgpu::BlendState {
+                        color: wgpu::BlendComponent::OVER,
+                        alpha: wgpu::BlendComponent::OVER,
+                    }),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: Default::default(),
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleStrip,
+                strip_index_format: None,
+                front_face: wgpu::FrontFace::Cw,
+                cull_mode: Some(wgpu::Face::Back),
+                polygon_mode: wgpu::PolygonMode::Fill,
+                unclipped_depth: false,
+                conservative: false,
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState {
+                count: 1,
+                mask: !0,
+                alpha_to_coverage_enabled: false,
+            },
+            multiview: None,
+            cache: None,
+        });
+        let quad = Geometry::new(&device);
 
         let state = State {
             window,
+            pipeline,
             device,
             queue,
             size,
             surface,
             surface_format,
+            quad,
         };
 
-        // Configure surface for the first time
         state.configure_surface();
 
         state
@@ -71,8 +148,7 @@ impl State {
         let surface_config = wgpu::SurfaceConfiguration {
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
             format: self.surface_format,
-            // Request compatibility with the sRGB-format texture view we‘re going to create later.
-            view_formats: vec![self.surface_format.add_srgb_suffix()],
+            view_formats: vec![self.surface_format],
             alpha_mode: wgpu::CompositeAlphaMode::Auto,
             width: self.size.width,
             height: self.size.height,
@@ -83,56 +159,55 @@ impl State {
     }
 
     fn resize(&mut self, new_size: winit::dpi::PhysicalSize<u32>) {
-        self.size = new_size;
-
-        // reconfigure the surface
-        self.configure_surface();
+        if new_size.width > 0 && new_size.height > 0 {
+            self.size = new_size;
+            self.configure_surface();
+        }
     }
 
     fn render(&mut self) {
-        // Create texture view
         let surface_texture = self
             .surface
             .get_current_texture()
             .expect("failed to acquire next swapchain texture");
-        let mut texture1 = surface_texture.texture.clone();
-        webrender::TEXTURE.with_borrow(|t| {
-            if let Some(texture) = t {
-                texture1 = texture.clone();
+        let frame = surface_texture
+            .texture
+            .create_view(&wgpu::TextureViewDescriptor {
+                label: Some("Surface"),
+                format: Some(wgpu::TextureFormat::Bgra8Unorm),
+                ..Default::default()
+            });
+
+        let mut encoder = self
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("Render Encoder"),
+            });
+        TEXTURE.with_borrow_mut(|textures| {
+            let Some(bind_group) = textures.as_ref() else {
+                return;
+            };
+            {
+                let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                    label: Some("Cef Render Pass"),
+                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                        view: &frame,
+                        resolve_target: None,
+                        ops: wgpu::Operations {
+                            load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                            store: wgpu::StoreOp::Store,
+                        },
+                    })],
+                    ..Default::default()
+                });
+                render_pass.set_pipeline(&self.pipeline);
+                render_pass.set_bind_group(0, bind_group, &[]);
+                render_pass.set_vertex_buffer(0, self.quad.vertex_buffer.slice(..));
+                render_pass.draw(0..self.quad.vertex_count, 0..1);
             }
-        });
-        let texture_view = texture1.create_view(&wgpu::TextureViewDescriptor {
-            // Without add_srgb_suffix() the image we will be working with
-            // might not be "gamma correct".
-            format: Some(self.surface_format.add_srgb_suffix()),
-            ..Default::default()
+            self.queue.submit(std::iter::once(encoder.finish()));
         });
 
-        // Renders a GREEN screen
-        let mut encoder = self.device.create_command_encoder(&Default::default());
-        // Create the renderpass which will clear the screen.
-        let renderpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-            label: None,
-            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                view: &texture_view,
-                resolve_target: None,
-                ops: wgpu::Operations {
-                    load: wgpu::LoadOp::Clear(wgpu::Color::GREEN),
-                    store: wgpu::StoreOp::Store,
-                },
-            })],
-            depth_stencil_attachment: None,
-            timestamp_writes: None,
-            occlusion_query_set: None,
-        });
-
-        // If you wanted to call any drawing commands, they would go here.
-
-        // End the renderpass.
-        drop(renderpass);
-
-        // Submit the command in the queue to execute
-        self.queue.submit([encoder.finish()]);
         self.window.pre_present_notify();
         surface_texture.present();
     }
@@ -140,15 +215,18 @@ impl State {
 
 struct App {
     state: Option<State>,
-    runtime: Runtime,
     browser: Option<Browser>,
+}
+
+struct Browser {
+    browser: cef::Browser,
+    size: std::rc::Rc<RefCell<winit::dpi::LogicalSize<f32>>>,
 }
 
 impl App {
     fn new() -> Self {
         App {
             state: None,
-            runtime: tokio::runtime::Runtime::new().unwrap(),
             browser: None,
         }
     }
@@ -156,10 +234,9 @@ impl App {
 
 impl ApplicationHandler for App {
     fn resumed(&mut self, event_loop: &ActiveEventLoop) {
-        // Create window object
         let window = Arc::new(
             event_loop
-                .create_window(Window::default_attributes())
+                .create_window(WindowAttributes::default())
                 .unwrap(),
         );
 
@@ -168,10 +245,14 @@ impl ApplicationHandler for App {
         let mut window_info = WindowInfo::default();
         window_info.windowless_rendering_enabled = true as _;
         window_info.shared_texture_enabled = true as _;
-        let render_handler = OsrRenderHandler::new(
+        window_info.external_begin_frame_enabled = true as _;
+        let device_scale_factor = window.scale_factor();
+        let (render_handler, browser_size) = OsrRenderHandler::new(
             self.state.as_ref().unwrap().device.clone(),
-            window.scale_factor() as _,
+            device_scale_factor as _,
+            window.inner_size().to_logical(device_scale_factor),
         );
+
         let mut browser_settings = BrowserSettings::default();
         browser_settings.windowless_frame_rate = 60;
         let mut context = cef::request_context_create_context(
@@ -190,7 +271,11 @@ impl ApplicationHandler for App {
             context.as_mut(),
         );
         assert!(browser.is_some());
-        self.browser = browser;
+
+        self.browser.replace(Browser {
+            browser: browser.unwrap(),
+            size: browser_size,
+        });
 
         window.request_redraw();
     }
@@ -199,18 +284,24 @@ impl ApplicationHandler for App {
         let state = self.state.as_mut().unwrap();
         match event {
             WindowEvent::CloseRequested => {
-                println!("The close button was pressed; stopping");
                 event_loop.exit();
             }
             WindowEvent::RedrawRequested => {
+                if let Some(host) = self.browser.as_mut().and_then(|b| b.browser.host()) {
+                    host.send_external_begin_frame();
+                }
                 state.render();
-                // Emits a new redraw requested event.
                 state.get_window().request_redraw();
             }
             WindowEvent::Resized(size) => {
-                // Reconfigures the size of the surface. We do not re-render
-                // here as this event is always followed up by redraw request.
                 state.resize(size);
+                if let Some(browser) = self.browser.as_mut() {
+                    *browser.size.borrow_mut() =
+                        size.to_logical(self.state.as_ref().unwrap().get_window().scale_factor());
+                    if let Some(host) = self.browser.as_mut().and_then(|b| b.browser.host()) {
+                        host.was_resized();
+                    }
+                }
             }
             _ => (),
         }
@@ -218,6 +309,9 @@ impl ApplicationHandler for App {
 }
 
 fn main() -> std::process::ExitCode {
+    #[cfg(all(target_os = "windows", debug_assertions))]
+    pix::load_winpix_gpu_capturer().unwrap();
+
     env_logger::init();
 
     #[cfg(target_os = "macos")]
@@ -242,7 +336,6 @@ fn main() -> std::process::ExitCode {
     );
 
     if is_browser_process {
-        println!("launch browser process");
         assert!(ret == -1, "cannot execute browser process");
     } else {
         let process_type = CefString::from(&cmd.switch_value(Some(&switch)));
@@ -266,17 +359,7 @@ fn main() -> std::process::ExitCode {
 
     let mut event_loop = EventLoop::new().unwrap();
 
-    // When the current loop iteration finishes, immediately begin a new
-    // iteration regardless of whether or not new events are available to
-    // process. Preferred for applications that want to render as fast as
-    // possible, like games.
     event_loop.set_control_flow(ControlFlow::Poll);
-
-    // When the current loop iteration finishes, suspend the thread until
-    // another event arrives. Helps keeping CPU utilization low if nothing
-    // is happening, which is preferred if the application might be idling in
-    // the background.
-    // event_loop.set_control_flow(ControlFlow::Wait);
 
     let mut app = App::new();
     let ret = loop {
@@ -288,12 +371,129 @@ fn main() -> std::process::ExitCode {
             break ExitCode::from(exit_code as u8);
         }
 
-        // Sleep for 1/60 second to simulate application work
-        //
-        // Since `pump_events` doesn't block it will be important to
-        // throttle the loop in the app somehow.
-        sleep(Duration::from_millis(16));
+        sleep(Duration::from_millis(1000 / 17));
     };
     cef::shutdown();
     ret
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+struct Vertex {
+    position: [f32; 3],
+    tex_coords: [f32; 2],
+}
+
+impl Vertex {
+    const ATTRIBS: [wgpu::VertexAttribute; 2] =
+        wgpu::vertex_attr_array![0 => Float32x3, 1 => Float32x2];
+
+    fn desc<'a>() -> wgpu::VertexBufferLayout<'a> {
+        wgpu::VertexBufferLayout {
+            array_stride: std::mem::size_of::<Self>() as wgpu::BufferAddress,
+            step_mode: wgpu::VertexStepMode::Vertex,
+            attributes: &Self::ATTRIBS,
+        }
+    }
+}
+
+struct Geometry {
+    vertex_buffer: wgpu::Buffer,
+    vertex_count: u32,
+}
+
+impl Geometry {
+    fn new(device: &wgpu::Device) -> Self {
+        let x = -1.0;
+        let y = 1.0;
+        let width = 2.0;
+        let height = 2.0;
+        let z = 1.0; // Z value for 2D quad
+
+        let vertices = [
+            Vertex {
+                position: [x, y, z],
+                tex_coords: [0.0, 0.0],
+            },
+            Vertex {
+                position: [x + width, y, z],
+                tex_coords: [1.0, 0.0],
+            },
+            Vertex {
+                position: [x, y - height, z],
+                tex_coords: [0.0, 1.0],
+            },
+            Vertex {
+                position: [x + width, y - height, z],
+                tex_coords: [1.0, 1.0],
+            },
+        ];
+
+        let vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("Quad Vertex Buffer"),
+            contents: bytemuck::cast_slice(&vertices),
+            usage: wgpu::BufferUsages::VERTEX,
+        });
+
+        Self {
+            vertex_buffer,
+            vertex_count: vertices.len() as u32,
+        }
+    }
+}
+
+#[cfg(all(target_os = "windows", debug_assertions))]
+mod pix {
+    use libloading::Library;
+    use std::io::{Error, ErrorKind, Result};
+    use std::path::PathBuf;
+    use windows::Win32::System::LibraryLoader::GetModuleHandleW;
+    use windows::core::{HSTRING, PCWSTR};
+
+    fn get_latest_winpix_gpu_capturer_path() -> PathBuf {
+        PathBuf::from(r"C:\Program Files")
+            .join("Microsoft PIX")
+            .join("2505.30")
+            .join("WinPixGpuCapturer.dll")
+    }
+
+    pub fn load_winpix_gpu_capturer() -> Result<()> {
+        let module_name = HSTRING::from("WinPixGpuCapturer.dll");
+
+        unsafe {
+            let module_pcwstr = PCWSTR::from_raw(module_name.as_ptr());
+            let is_loaded = GetModuleHandleW(module_pcwstr).is_ok();
+
+            if !is_loaded {
+                let path = get_latest_winpix_gpu_capturer_path();
+
+                if !path.exists() {
+                    return Err(Error::new(
+                        ErrorKind::NotFound,
+                        format!("WinPixGpuCapturer.dll not found at {}", path.display()),
+                    ));
+                }
+
+                match Library::new(&path) {
+                    Ok(lib) => {
+                        use std::sync::Once;
+                        static INIT: Once = Once::new();
+                        static mut LIBRARY: Option<Library> = None;
+
+                        INIT.call_once(|| {
+                            LIBRARY = Some(lib);
+                        });
+
+                        Ok(())
+                    }
+                    Err(e) => Err(Error::new(
+                        ErrorKind::Other,
+                        format!("Failed to load WinPixGpuCapturer.dll: {}", e),
+                    )),
+                }
+            } else {
+                Ok(())
+            }
+        }
+    }
 }

--- a/cef/examples/osr/src/shader.wgsl
+++ b/cef/examples/osr/src/shader.wgsl
@@ -1,0 +1,28 @@
+// Vertex shader
+struct VertexInput {
+    @location(0) pos: vec4<f32>,
+    @location(1) tex: vec2<f32>,
+};
+
+struct VertexOutput {
+    @builtin(position) pos: vec4<f32>,
+    @location(0) tex: vec2<f32>,
+};
+
+@vertex
+fn vs_main(input: VertexInput) -> VertexOutput {
+    var output: VertexOutput;
+    output.pos = input.pos;
+    output.tex = input.tex;
+    return output;
+}
+
+// Fragment shader
+@group(0) @binding(0) var tex0: texture_2d<f32>;
+@group(0) @binding(1) var samp0: sampler;
+
+@fragment
+fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
+    return textureSample(tex0, samp0, input.tex);
+}
+

--- a/cef/examples/osr/src/webrender.rs
+++ b/cef/examples/osr/src/webrender.rs
@@ -1,0 +1,469 @@
+use cef::{
+    self, BrowserProcessHandler, ImplBrowserProcessHandler, WrapBrowserProcessHandler,
+    rc::{Rc, RcImpl},
+    sys::{self, cef_color_type_t},
+    *,
+};
+use cef::{ImplRequestContextHandler, RequestContextHandler, WrapRequestContextHandler};
+use std::cell::RefCell;
+use std::ptr::null_mut;
+use wgpu::{
+    Extent3d, Texture, TextureDescriptor, TextureDimension, TextureUsages, TextureUses,
+    hal::MemoryFlags,
+    wgc::api::{Dx12, Vulkan},
+};
+use windows::Win32::Graphics::Direct3D12;
+
+#[derive(Clone)]
+pub struct OsrApp {}
+
+impl OsrApp {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+pub(crate) struct AppBuilder {
+    object: *mut RcImpl<cef::sys::_cef_app_t, Self>,
+    app: OsrApp,
+}
+
+impl AppBuilder {
+    pub(crate) fn build(app: OsrApp) -> cef::App {
+        cef::App::new(Self {
+            object: std::ptr::null_mut(),
+            app,
+        })
+    }
+}
+
+impl WrapApp for AppBuilder {
+    fn wrap_rc(&mut self, object: *mut RcImpl<cef::sys::_cef_app_t, Self>) {
+        self.object = object;
+    }
+}
+
+impl Clone for AppBuilder {
+    fn clone(&self) -> Self {
+        let object = unsafe {
+            let rc = &mut *self.object;
+            rc.interface.add_ref();
+            self.object
+        };
+        Self {
+            object,
+            app: self.app.clone(),
+        }
+    }
+}
+
+impl Rc for AppBuilder {
+    fn as_base(&self) -> &cef::sys::cef_base_ref_counted_t {
+        unsafe {
+            let base = &*self.object;
+            std::mem::transmute(&base.cef_object)
+        }
+    }
+}
+
+impl ImplApp for AppBuilder {
+    fn get_raw(&self) -> *mut cef::sys::_cef_app_t {
+        self.object as *mut cef::sys::_cef_app_t
+    }
+
+    fn on_before_command_line_processing(
+        &self,
+        _process_type: Option<&cef::CefStringUtf16>,
+        command_line: Option<&mut cef::CommandLine>,
+    ) {
+        let Some(command_line) = command_line else {
+            return;
+        };
+
+        command_line.append_switch(Some(&"no-startup-window".into()));
+        command_line.append_switch(Some(&"noerrdialogs".into()));
+        command_line.append_switch(Some(&"hide-crash-restore-bubble".into()));
+        command_line.append_switch(Some(&"use-mock-keychain".into()));
+        command_line
+            .append_switch_with_value(Some(&"remote-debugging-port".into()), Some(&"9229".into()));
+    }
+
+    fn browser_process_handler(&self) -> Option<cef::BrowserProcessHandler> {
+        Some(BrowserProcessHandlerBuilder::build(
+            OsrBrowserProcessHandler::new(),
+        ))
+    }
+}
+
+#[derive(Clone)]
+pub struct OsrBrowserProcessHandler {
+    is_cef_ready: RefCell<bool>,
+}
+
+impl OsrBrowserProcessHandler {
+    pub fn new() -> Self {
+        Self {
+            is_cef_ready: RefCell::new(false),
+        }
+    }
+}
+
+pub(crate) struct BrowserProcessHandlerBuilder {
+    object: *mut RcImpl<sys::cef_browser_process_handler_t, Self>,
+    handler: OsrBrowserProcessHandler,
+}
+
+impl BrowserProcessHandlerBuilder {
+    pub(crate) fn build(handler: OsrBrowserProcessHandler) -> BrowserProcessHandler {
+        BrowserProcessHandler::new(Self {
+            object: std::ptr::null_mut(),
+            handler,
+        })
+    }
+}
+
+impl Rc for BrowserProcessHandlerBuilder {
+    fn as_base(&self) -> &sys::cef_base_ref_counted_t {
+        unsafe {
+            let base = &*self.object;
+            std::mem::transmute(&base.cef_object)
+        }
+    }
+}
+
+impl WrapBrowserProcessHandler for BrowserProcessHandlerBuilder {
+    fn wrap_rc(&mut self, object: *mut RcImpl<sys::_cef_browser_process_handler_t, Self>) {
+        self.object = object;
+    }
+}
+
+impl Clone for BrowserProcessHandlerBuilder {
+    fn clone(&self) -> Self {
+        let object = unsafe {
+            let rc_impl = &mut *self.object;
+            rc_impl.interface.add_ref();
+            rc_impl
+        };
+
+        Self {
+            object,
+            handler: self.handler.clone(),
+        }
+    }
+}
+
+impl ImplBrowserProcessHandler for BrowserProcessHandlerBuilder {
+    fn get_raw(&self) -> *mut sys::_cef_browser_process_handler_t {
+        self.object.cast()
+    }
+
+    fn on_context_initialized(&self) {
+        *self.handler.is_cef_ready.borrow_mut() = true;
+    }
+
+    fn on_before_child_process_launch(&self, command_line: Option<&mut CommandLine>) {
+        let Some(command_line) = command_line else {
+            return;
+        };
+
+        command_line.append_switch(Some(&"disable-web-security".into()));
+        command_line.append_switch(Some(&"allow-running-insecure-content".into()));
+        command_line.append_switch(Some(&"disable-session-crashed-bubble".into()));
+        command_line.append_switch(Some(&"ignore-certificate-errors".into()));
+        command_line.append_switch(Some(&"ignore-ssl-errors".into()));
+    }
+}
+
+#[derive(Clone)]
+pub struct OsrRenderHandler {
+    device_scale_factor: f32,
+    device: wgpu::Device,
+}
+
+impl OsrRenderHandler {
+    pub fn new(device: wgpu::Device, device_scale_factor: f32) -> Self {
+        Self {
+            device_scale_factor,
+            device,
+        }
+    }
+}
+
+pub struct RenderHandlerBuilder {
+    object: *mut RcImpl<sys::cef_render_handler_t, Self>,
+    handler: OsrRenderHandler,
+}
+
+impl RenderHandlerBuilder {
+    pub fn build(handler: OsrRenderHandler) -> RenderHandler {
+        RenderHandler::new(Self {
+            object: null_mut(),
+            handler,
+        })
+    }
+}
+
+impl Rc for RenderHandlerBuilder {
+    fn as_base(&self) -> &sys::cef_base_ref_counted_t {
+        unsafe {
+            let base = &*self.object;
+            std::mem::transmute(&base.cef_object)
+        }
+    }
+}
+impl WrapRenderHandler for RenderHandlerBuilder {
+    fn wrap_rc(&mut self, object: *mut RcImpl<sys::_cef_render_handler_t, Self>) {
+        self.object = object;
+    }
+}
+impl Clone for RenderHandlerBuilder {
+    fn clone(&self) -> Self {
+        let object = unsafe {
+            let rc_impl = &mut *self.object;
+            rc_impl.interface.add_ref();
+            rc_impl
+        };
+
+        Self {
+            object,
+            handler: self.handler.clone(),
+        }
+    }
+}
+
+impl ImplRenderHandler for RenderHandlerBuilder {
+    fn get_raw(&self) -> *mut sys::_cef_render_handler_t {
+        self.object.cast()
+    }
+
+    fn view_rect(&self, _browser: Option<&mut Browser>, rect: Option<&mut Rect>) {
+        if let Some(rect) = rect {
+            rect.x = 0;
+            rect.y = 0;
+            rect.width = 800;
+            rect.height = 600;
+        }
+    }
+
+    fn screen_info(
+        &self,
+        _browser: Option<&mut Browser>,
+        screen_info: Option<&mut ScreenInfo>,
+    ) -> ::std::os::raw::c_int {
+        if let Some(screen_info) = screen_info {
+            screen_info.device_scale_factor = self.handler.device_scale_factor;
+            return true as _;
+        }
+        return false as _;
+    }
+
+    fn screen_point(
+        &self,
+        _browser: Option<&mut Browser>,
+        _view_x: ::std::os::raw::c_int,
+        _view_y: ::std::os::raw::c_int,
+        _screen_x: Option<&mut ::std::os::raw::c_int>,
+        _screen_y: Option<&mut ::std::os::raw::c_int>,
+    ) -> ::std::os::raw::c_int {
+        return false as _;
+    }
+
+    fn on_accelerated_paint(
+        &self,
+        browser: Option<&mut Browser>,
+        type_: PaintElementType,
+        dirty_rects_count: usize,
+        dirty_rects: Option<&Rect>,
+        info: Option<&AcceleratedPaintInfo>,
+    ) {
+        let Some(info) = info else { return };
+        let format = match info.format.as_ref() {
+            cef_color_type_t::CEF_COLOR_TYPE_BGRA_8888 => wgpu::TextureFormat::Bgra8UnormSrgb,
+            cef_color_type_t::CEF_COLOR_TYPE_RGBA_8888 => wgpu::TextureFormat::Rgba8UnormSrgb,
+            _ => panic!("Unsupported color type"),
+        };
+        let texture_desc = TextureDescriptor {
+            label: Some("cef"),
+            size: Extent3d {
+                width: info.extra.coded_size.width as _,
+                height: info.extra.coded_size.height as _,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: TextureDimension::D2,
+            format,
+            usage: TextureUsages::COPY_DST | TextureUsages::RENDER_ATTACHMENT,
+            view_formats: &[],
+        };
+        let handle = windows::Win32::Foundation::HANDLE(info.shared_texture_handle.cast());
+        let resource = unsafe {
+            //self.handler.device.as_hal::<Vulkan, _, _>(|hdevice| {
+            //    hdevice.map(|device| {
+            //        let desc = wgpu::hal::TextureDescriptor {
+            //            label: "cef-vulkan".into(),
+            //            size: Extent3d {
+            //                width: info.extra.coded_size.width as _,
+            //                height: info.extra.coded_size.height as _,
+            //                depth_or_array_layers: 1,
+            //            },
+            //            mip_level_count: 1,
+            //            sample_count: 1,
+            //            dimension: TextureDimension::D2,
+            //            format,
+            //            usage: TextureUses::COPY_DST,
+            //            memory_flags: MemoryFlags::empty(),
+            //            view_formats: vec![],
+            //        };
+            //        device.texture_from_d3d11_shared_handle(handle, &desc)
+            //    })
+            //})
+            self.handler.device.as_hal::<Dx12, _, _>(|hdevice| {
+                hdevice.map(|hdevice| {
+                    let raw_device = hdevice.raw_device();
+
+                    let mut resource = None::<Direct3D12::ID3D12Resource>;
+                    match raw_device.OpenSharedHandle(handle, &mut resource) {
+                        Ok(_) => Ok(resource.unwrap()),
+                        Err(e) => Err(e),
+                    }
+                })
+            })
+        };
+        let resource = resource.unwrap().unwrap();
+
+        unsafe {
+            let texture = <Dx12 as wgpu::hal::Api>::Device::texture_from_raw(
+                resource,
+                texture_desc.format,
+                texture_desc.dimension,
+                texture_desc.size,
+                1,
+                1,
+            );
+
+            TEXTURE.with_borrow_mut(|t| {
+                t.replace(
+                    self.handler
+                        .device
+                        .create_texture_from_hal::<Dx12>(texture, &texture_desc),
+                )
+            });
+        }
+    }
+}
+
+thread_local! {
+    pub static TEXTURE: RefCell<Option<Texture>> = RefCell::new(None);
+}
+
+pub(crate) struct ClientBuilder {
+    object: *mut RcImpl<sys::cef_client_t, Self>,
+    render_handler: RenderHandler,
+}
+
+impl ClientBuilder {
+    pub(crate) fn build(render_handler: OsrRenderHandler) -> Client {
+        Client::new(Self {
+            object: null_mut(),
+            render_handler: RenderHandlerBuilder::build(render_handler),
+        })
+    }
+}
+
+impl Rc for ClientBuilder {
+    fn as_base(&self) -> &sys::cef_base_ref_counted_t {
+        unsafe {
+            let base = &*self.object;
+            std::mem::transmute(&base.cef_object)
+        }
+    }
+}
+
+impl WrapClient for ClientBuilder {
+    fn wrap_rc(&mut self, object: *mut RcImpl<sys::cef_client_t, Self>) {
+        self.object = object;
+    }
+}
+
+impl Clone for ClientBuilder {
+    fn clone(&self) -> Self {
+        let object = unsafe {
+            let rc_impl = &mut *self.object;
+            rc_impl.interface.add_ref();
+            rc_impl
+        };
+
+        Self {
+            object,
+            render_handler: self.render_handler.clone(),
+        }
+    }
+}
+
+impl ImplClient for ClientBuilder {
+    fn get_raw(&self) -> *mut sys::_cef_client_t {
+        self.object.cast()
+    }
+
+    fn render_handler(&self) -> Option<cef::RenderHandler> {
+        Some(self.render_handler.clone())
+    }
+}
+
+#[derive(Clone)]
+pub struct OsrRequestContextHandler {}
+
+pub(crate) struct RequestContextHandlerBuilder {
+    object: *mut RcImpl<sys::cef_request_context_handler_t, Self>,
+    handler: OsrRequestContextHandler,
+}
+
+impl RequestContextHandlerBuilder {
+    pub(crate) fn build(handler: OsrRequestContextHandler) -> RequestContextHandler {
+        RequestContextHandler::new(Self {
+            object: null_mut(),
+            handler,
+        })
+    }
+}
+
+impl WrapRequestContextHandler for RequestContextHandlerBuilder {
+    fn wrap_rc(&mut self, object: *mut RcImpl<sys::_cef_request_context_handler_t, Self>) {
+        self.object = object;
+    }
+}
+
+impl Rc for RequestContextHandlerBuilder {
+    fn as_base(&self) -> &sys::cef_base_ref_counted_t {
+        unsafe {
+            let base = &*self.object;
+            std::mem::transmute(&base.cef_object)
+        }
+    }
+}
+
+impl Clone for RequestContextHandlerBuilder {
+    fn clone(&self) -> Self {
+        let object = unsafe {
+            let rc_impl = &mut *self.object;
+            rc_impl.interface.add_ref();
+            rc_impl
+        };
+
+        Self {
+            object,
+            handler: self.handler.clone(),
+        }
+    }
+}
+
+impl ImplRequestContextHandler for RequestContextHandlerBuilder {
+    fn get_raw(&self) -> *mut sys::_cef_request_context_handler_t {
+        self.object.cast()
+    }
+
+    fn on_request_context_initialized(&self, _request_context: Option<&mut cef::RequestContext>) {
+        dbg!("on_request_context_initialized");
+    }
+}

--- a/cef/examples/osr/src/webrender.rs
+++ b/cef/examples/osr/src/webrender.rs
@@ -7,11 +7,10 @@ use cef::{
 use cef::{ImplRequestContextHandler, RequestContextHandler, WrapRequestContextHandler};
 use std::cell::RefCell;
 use std::ptr::null_mut;
-use wgpu::{
-    Extent3d, Texture, TextureDescriptor, TextureDimension, TextureUsages, TextureUses,
-    hal::MemoryFlags,
-    wgc::api::{Dx12, Vulkan},
-};
+#[cfg(target_os = "windows")]
+use wgpu::wgc::api::Dx12;
+use wgpu::{Extent3d, TextureDescriptor, TextureDimension, TextureUsages};
+#[cfg(target_os = "windows")]
 use windows::Win32::Graphics::Direct3D12;
 
 #[derive(Clone)]
@@ -84,6 +83,7 @@ impl ImplApp for AppBuilder {
         command_line.append_switch(Some(&"noerrdialogs".into()));
         command_line.append_switch(Some(&"hide-crash-restore-bubble".into()));
         command_line.append_switch(Some(&"use-mock-keychain".into()));
+        command_line.append_switch(Some(&"enable-logging=stderr".into()));
         command_line
             .append_switch_with_value(Some(&"remote-debugging-port".into()), Some(&"9229".into()));
     }
@@ -171,21 +171,32 @@ impl ImplBrowserProcessHandler for BrowserProcessHandlerBuilder {
         command_line.append_switch(Some(&"disable-session-crashed-bubble".into()));
         command_line.append_switch(Some(&"ignore-certificate-errors".into()));
         command_line.append_switch(Some(&"ignore-ssl-errors".into()));
+        command_line.append_switch(Some(&"enable-logging=stderr".into()));
     }
 }
 
 #[derive(Clone)]
 pub struct OsrRenderHandler {
     device_scale_factor: f32,
+    size: std::rc::Rc<RefCell<winit::dpi::LogicalSize<f32>>>,
     device: wgpu::Device,
 }
 
 impl OsrRenderHandler {
-    pub fn new(device: wgpu::Device, device_scale_factor: f32) -> Self {
-        Self {
-            device_scale_factor,
-            device,
-        }
+    pub fn new(
+        device: wgpu::Device,
+        device_scale_factor: f32,
+        size: winit::dpi::LogicalSize<f32>,
+    ) -> (Self, std::rc::Rc<RefCell<winit::dpi::LogicalSize<f32>>>) {
+        let size = std::rc::Rc::new(RefCell::new(size));
+        (
+            Self {
+                size: size.clone(),
+                device_scale_factor,
+                device,
+            },
+            size,
+        )
     }
 }
 
@@ -238,10 +249,12 @@ impl ImplRenderHandler for RenderHandlerBuilder {
 
     fn view_rect(&self, _browser: Option<&mut Browser>, rect: Option<&mut Rect>) {
         if let Some(rect) = rect {
-            rect.x = 0;
-            rect.y = 0;
-            rect.width = 800;
-            rect.height = 600;
+            let size = self.handler.size.borrow();
+            // size must be non-zero
+            if size.width > 0.0 && size.height > 0.0 {
+                rect.width = size.width as _;
+                rect.height = size.height as _;
+            }
         }
     }
 
@@ -268,22 +281,23 @@ impl ImplRenderHandler for RenderHandlerBuilder {
         return false as _;
     }
 
+    #[cfg(target_os = "windows")]
     fn on_accelerated_paint(
         &self,
-        browser: Option<&mut Browser>,
-        type_: PaintElementType,
-        dirty_rects_count: usize,
-        dirty_rects: Option<&Rect>,
+        _browser: Option<&mut Browser>,
+        _type_: PaintElementType,
+        _dirty_rects_count: usize,
+        _dirty_rects: Option<&Rect>,
         info: Option<&AcceleratedPaintInfo>,
     ) {
         let Some(info) = info else { return };
         let format = match info.format.as_ref() {
-            cef_color_type_t::CEF_COLOR_TYPE_BGRA_8888 => wgpu::TextureFormat::Bgra8UnormSrgb,
-            cef_color_type_t::CEF_COLOR_TYPE_RGBA_8888 => wgpu::TextureFormat::Rgba8UnormSrgb,
+            cef_color_type_t::CEF_COLOR_TYPE_BGRA_8888 => wgpu::TextureFormat::Bgra8Unorm,
+            cef_color_type_t::CEF_COLOR_TYPE_RGBA_8888 => wgpu::TextureFormat::Rgba8Unorm,
             _ => panic!("Unsupported color type"),
         };
         let texture_desc = TextureDescriptor {
-            label: Some("cef"),
+            label: Some("Cef Texture"),
             size: Extent3d {
                 width: info.extra.coded_size.width as _,
                 height: info.extra.coded_size.height as _,
@@ -293,31 +307,11 @@ impl ImplRenderHandler for RenderHandlerBuilder {
             sample_count: 1,
             dimension: TextureDimension::D2,
             format,
-            usage: TextureUsages::COPY_DST | TextureUsages::RENDER_ATTACHMENT,
+            usage: TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_SRC,
             view_formats: &[],
         };
         let handle = windows::Win32::Foundation::HANDLE(info.shared_texture_handle.cast());
         let resource = unsafe {
-            //self.handler.device.as_hal::<Vulkan, _, _>(|hdevice| {
-            //    hdevice.map(|device| {
-            //        let desc = wgpu::hal::TextureDescriptor {
-            //            label: "cef-vulkan".into(),
-            //            size: Extent3d {
-            //                width: info.extra.coded_size.width as _,
-            //                height: info.extra.coded_size.height as _,
-            //                depth_or_array_layers: 1,
-            //            },
-            //            mip_level_count: 1,
-            //            sample_count: 1,
-            //            dimension: TextureDimension::D2,
-            //            format,
-            //            usage: TextureUses::COPY_DST,
-            //            memory_flags: MemoryFlags::empty(),
-            //            view_formats: vec![],
-            //        };
-            //        device.texture_from_d3d11_shared_handle(handle, &desc)
-            //    })
-            //})
             self.handler.device.as_hal::<Dx12, _, _>(|hdevice| {
                 hdevice.map(|hdevice| {
                     let raw_device = hdevice.raw_device();
@@ -332,7 +326,7 @@ impl ImplRenderHandler for RenderHandlerBuilder {
         };
         let resource = resource.unwrap().unwrap();
 
-        unsafe {
+        let src_texture = unsafe {
             let texture = <Dx12 as wgpu::hal::Api>::Device::texture_from_raw(
                 resource,
                 texture_desc.format,
@@ -342,19 +336,109 @@ impl ImplRenderHandler for RenderHandlerBuilder {
                 1,
             );
 
-            TEXTURE.with_borrow_mut(|t| {
-                t.replace(
-                    self.handler
-                        .device
-                        .create_texture_from_hal::<Dx12>(texture, &texture_desc),
-                )
+            self.handler
+                .device
+                .create_texture_from_hal::<Dx12>(texture, &texture_desc)
+        };
+        //let dst_texture = self
+        //    .handler
+        //    .device
+        //    .create_texture(&wgpu::TextureDescriptor {
+        //        label: Some("Cef Dst Texture"),
+        //        usage: TextureUsages::TEXTURE_BINDING
+        //            | TextureUsages::COPY_DST
+        //            | TextureUsages::RENDER_ATTACHMENT,
+        //        ..texture_desc
+        //    });
+
+        //let texture_view = dst_texture.create_view(&TextureViewDescriptor {
+        //    label: Some("Cef Texture View"),
+        //    ..Default::default()
+        //});
+        // Cef's on_accelerated_paint recommands to copy the texture, but it seems work without
+        // copy. And copying works too, leave it here for future reference
+        //
+        //       let mut encoder =
+        //            self.handler
+        //                .device
+        //                .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        //                    label: Some("Texture Copy Encoder"),
+        //                });
+        //
+        //wgpu::util::TextureBlitter::new(&self.handler.device, texture_desc.format).copy(
+        //    &self.handler.device,
+        //    &mut encoder,
+        //    &src_texture.create_view(&Default::default()),
+        //    &texture_view,
+        //);
+        let sampler = self
+            .handler
+            .device
+            .create_sampler(&wgpu::SamplerDescriptor {
+                address_mode_u: wgpu::AddressMode::ClampToEdge,
+                address_mode_v: wgpu::AddressMode::ClampToEdge,
+                address_mode_w: wgpu::AddressMode::ClampToEdge,
+                mag_filter: wgpu::FilterMode::Linear,
+                min_filter: wgpu::FilterMode::Linear,
+                mipmap_filter: wgpu::FilterMode::Linear,
+                ..Default::default()
             });
-        }
+        let texture_bind_group_layout =
+            self.handler
+                .device
+                .create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                    label: Some("Cef Texture Bind Group Layout"),
+                    entries: &[
+                        wgpu::BindGroupLayoutEntry {
+                            binding: 0,
+                            visibility: wgpu::ShaderStages::FRAGMENT,
+                            ty: wgpu::BindingType::Texture {
+                                multisampled: false,
+                                view_dimension: wgpu::TextureViewDimension::D2,
+                                sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                            },
+                            count: None,
+                        },
+                        wgpu::BindGroupLayoutEntry {
+                            binding: 1,
+                            visibility: wgpu::ShaderStages::FRAGMENT,
+                            ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                            count: None,
+                        },
+                    ],
+                });
+
+        let bind_group = self
+            .handler
+            .device
+            .create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("Cef Texture Bind Group"),
+                layout: &texture_bind_group_layout,
+                entries: &[
+                    wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: wgpu::BindingResource::TextureView(&src_texture.create_view(
+                            &wgpu::TextureViewDescriptor {
+                                label: Some("Cef Texture View"),
+                                ..Default::default()
+                            },
+                        )),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 1,
+                        resource: wgpu::BindingResource::Sampler(&sampler),
+                    },
+                ],
+            });
+
+        TEXTURE.with_borrow_mut(|texture| {
+            texture.replace(bind_group);
+        });
     }
 }
 
 thread_local! {
-    pub static TEXTURE: RefCell<Option<Texture>> = RefCell::new(None);
+    pub static TEXTURE: RefCell<Option<wgpu::BindGroup>> = RefCell::new(None);
 }
 
 pub(crate) struct ClientBuilder {
@@ -461,9 +545,5 @@ impl Clone for RequestContextHandlerBuilder {
 impl ImplRequestContextHandler for RequestContextHandlerBuilder {
     fn get_raw(&self) -> *mut sys::_cef_request_context_handler_t {
         self.object.cast()
-    }
-
-    fn on_request_context_initialized(&self, _request_context: Option<&mut cef::RequestContext>) {
-        dbg!("on_request_context_initialized");
     }
 }


### PR DESCRIPTION
Dare I say, no rust app will use the bare window and view apis provided by cef to create their ui, So most of them will come for the offscreen rendering function of cef(even tauri I guess).

This is a minimal demo to verify the gpu resource handle from cef can be opened with wgpu, should be helpful for apps to embedded cef.

~~(It can run on windows now, but the surface is still black, debugging)~~