### PR TITLE
fix: bump version for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "138.5.1+138.0.27"
+version = "138.6.0+138.0.27"
 edition = "2021"
 license = "Apache-2.0 OR MIT"
 authors = [
@@ -22,7 +22,7 @@ authors = [
 repository = "https://github.com/tauri-apps/cef-rs"
 
 [workspace.dependencies]
-cef-dll-sys = { version = "138.5.1", path = "sys" }
+cef-dll-sys = { version = "138.6.0", path = "sys" }
 download-cef = { version = "2.0", path = "download-cef" }
 
 anyhow = "1"


### PR DESCRIPTION
The `get-latest` workflow for 138.0.27 updated the build metadata but didn't bump the crate version, expecting the `release-plz` workflow to handle that. However, the `release-plz` workflow thought that the difference in the build metadata meant that there was already a version bump, and it skipped the PR phase and went straight to a publish step, which failed because crates.io considered the 2 versions equivalent.