### PR TITLE
fix: align cefsimple `LSUIElement` with official CEF

### DIFF
--- a/examples/cefsimple/src/mac/bundle_cefsimple.rs
+++ b/examples/cefsimple/src/mac/bundle_cefsimple.rs
@@ -122,7 +122,11 @@ mod mac {
                 .collect(),
             ls_file_quarantine_enabled: true,
             ls_minimum_system_version: "11.0".to_string(),
-            ls_ui_element: if is_helper { Some("1".to_string()) } else { None },
+            ls_ui_element: if is_helper {
+                Some("1".to_string())
+            } else {
+                None
+            },
             ns_bluetooth_always_usage_description: exec_name.to_string(),
             ns_supports_automatic_graphics_switching: true,
             ns_web_browser_publickey_credential_usage_description: exec_name.to_string(),


### PR DESCRIPTION
Remove `LSUIElement` for the main app bundle to prevent crashes with CEF debug builds and ensure the Dock icon is visible. The previous setting was incorrect and only meant for helper processes.