### PR TITLE
Export cef and chrome version info

### DIFF
--- a/update-bindings/src/upgrade.rs
+++ b/update-bindings/src/upgrade.rs
@@ -56,6 +56,8 @@ fn bindgen(target: &str, cef_path: &Path) -> crate::Result<()> {
         .allowlist_type("cef_.*")
         .allowlist_function("cef_.*")
         .allowlist_item("CEF_API_VERSION(_.+)?")
+        .allowlist_item("CEF_VERSION(_.+)?")
+        .allowlist_item("CHROME_VERSION(_.+)?")
         .default_macro_constant_type(bindgen::MacroTypeVariation::Signed)
         .bitfield_enum(".*_mask_t")
         .clang_args([


### PR DESCRIPTION
Should be useful for users to construct their product agent in the user agent.