### PR TITLE
feat: offscreen renderering on macOS example

### DIFF
--- a/examples/cefsimple/src/mac/helper.rs
+++ b/examples/cefsimple/src/mac/helper.rs
@@ -4,9 +4,8 @@ fn main() {
     let args = Args::new();
 
     #[cfg(all(target_os = "macos", feature = "sandbox"))]
-    let mut _sandbox = {
+    let _sandbox = {
         let mut sandbox = cef::sandbox::Sandbox::new();
-
         sandbox.initialize(args.as_main_args());
         sandbox
     };

--- a/examples/cefsimple/src/mac/helper.rs
+++ b/examples/cefsimple/src/mac/helper.rs
@@ -4,8 +4,9 @@ fn main() {
     let args = Args::new();
 
     #[cfg(all(target_os = "macos", feature = "sandbox"))]
-    let _sandbox = {
+    let mut _sandbox = {
         let mut sandbox = cef::sandbox::Sandbox::new();
+
         sandbox.initialize(args.as_main_args());
         sandbox
     };

--- a/examples/osr/Cargo.toml
+++ b/examples/osr/Cargo.toml
@@ -11,8 +11,14 @@ pollster = "0.4"
 wgpu = "25"
 tokio = { version = "1", features = ["full"] }
 winit = { version = "0.30" }
-windows = { version = "0.58", features = ["Win32_Graphics_Direct3D12"] }
-bytemuck = "*"
+bytemuck = "1"
 
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = { version = "0.58", features = ["Win32_Graphics_Direct3D12"] }
 # For gpu debugging on Windows with PIX
 libloading = "0.8"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+metal = "0.32"
+objc = "0.2"
+io-surface = "0.16"

--- a/examples/osr/Cargo.toml
+++ b/examples/osr/Cargo.toml
@@ -19,6 +19,6 @@ windows = { version = "0.58", features = ["Win32_Graphics_Direct3D12"] }
 libloading = "0.8"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-metal = "0.32"
+metal = "0.31"
 objc = "0.2"
 io-surface = "0.16"

--- a/examples/osr/src/main.rs
+++ b/examples/osr/src/main.rs
@@ -351,9 +351,11 @@ fn main() -> std::process::ExitCode {
         // non-browser process does not initialize cef
         return 0.into();
     }
-    let mut settings = Settings::default();
-    settings.windowless_rendering_enabled = true as _;
-    settings.external_message_pump = true as _;
+    let settings = Settings {
+        windowless_rendering_enabled: true as _,
+        external_message_pump: true as _,
+        ..Default::default()
+    };
     assert_eq!(
         initialize(
             Some(args.as_main_args()),
@@ -493,10 +495,9 @@ mod pix {
 
                         Ok(())
                     }
-                    Err(e) => Err(Error::new(
-                        ErrorKind::Other,
-                        format!("Failed to load WinPixGpuCapturer.dll: {}", e),
-                    )),
+                    Err(e) => Err(Error::other(format!(
+                        "Failed to load WinPixGpuCapturer.dll: {e}"
+                    ))),
                 }
             } else {
                 Ok(())

--- a/examples/osr/src/webrender.rs
+++ b/examples/osr/src/webrender.rs
@@ -5,13 +5,10 @@ use cef::{
     *,
 };
 use cef::{ImplRequestContextHandler, RequestContextHandler, WrapRequestContextHandler};
+use objc::msg_send;
 use std::cell::RefCell;
 use std::ptr::null_mut;
-#[cfg(target_os = "windows")]
-use wgpu::wgc::api::Dx12;
-use wgpu::{Extent3d, TextureDescriptor, TextureDimension, TextureUsages};
-#[cfg(target_os = "windows")]
-use windows::Win32::Graphics::Direct3D12;
+use wgpu::{Extent3d, TextureDescriptor, TextureDimension, TextureUsages, hal::Device};
 
 #[derive(Clone)]
 pub struct OsrApp {}
@@ -281,7 +278,6 @@ impl ImplRenderHandler for RenderHandlerBuilder {
         false as _
     }
 
-    #[cfg(target_os = "windows")]
     fn on_accelerated_paint(
         &self,
         _browser: Option<&mut Browser>,
@@ -310,23 +306,28 @@ impl ImplRenderHandler for RenderHandlerBuilder {
             usage: TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_SRC,
             view_formats: &[],
         };
-        let handle = windows::Win32::Foundation::HANDLE(info.shared_texture_handle.cast());
-        let resource = unsafe {
-            self.handler.device.as_hal::<Dx12, _, _>(|hdevice| {
-                hdevice.map(|hdevice| {
-                    let raw_device = hdevice.raw_device();
 
-                    let mut resource = None::<Direct3D12::ID3D12Resource>;
-                    match raw_device.OpenSharedHandle(handle, &mut resource) {
-                        Ok(_) => Ok(resource.unwrap()),
-                        Err(e) => Err(e),
-                    }
-                })
-            })
-        };
-        let resource = resource.unwrap().unwrap();
-
+        #[cfg(target_os = "windows")]
         let src_texture = unsafe {
+            let handle = windows::Win32::Foundation::HANDLE(info.shared_texture_handle.cast());
+            use wgpu::wgc::api::Dx12;
+            use windows::Win32::Graphics::Direct3D12;
+            let resource = self
+                .handler
+                .device
+                .as_hal::<Dx12, _, _>(|hdevice| {
+                    hdevice.map(|hdevice| {
+                        let raw_device = hdevice.raw_device();
+                        let mut resource = None::<Direct3D12::ID3D12Resource>;
+                        match raw_device.OpenSharedHandle(handle, &mut resource) {
+                            Ok(_) => Ok(resource.unwrap()),
+                            Err(e) => Err(e),
+                        }
+                    })
+                })
+                .unwrap()
+                .unwrap();
+
             let texture = <Dx12 as wgpu::hal::Api>::Device::texture_from_raw(
                 resource,
                 texture_desc.format,
@@ -339,6 +340,41 @@ impl ImplRenderHandler for RenderHandlerBuilder {
             self.handler
                 .device
                 .create_texture_from_hal::<Dx12>(texture, &texture_desc)
+        };
+
+        #[cfg(target_os = "macos")]
+        let src_texture = unsafe {
+            use io_surface::IOSurfaceRef;
+            let Some(io_surface) =
+                std::ptr::NonNull::new(info.shared_texture_io_surface.cast::<IOSurfaceRef>())
+            else {
+                return;
+            };
+            let desc = wgpu::hal::TextureDescriptor {
+                mip_level_count: texture_desc.mip_level_count,
+                view_formats: vec![],
+                sample_count: texture_desc.sample_count,
+                usage: wgpu::TextureUses::STORAGE_READ_ONLY,
+                label: Some("Cef Texture"),
+                dimension: texture_desc.dimension,
+                format: texture_desc.format,
+                size: texture_desc.size,
+                memory_flags: wgpu::hal::MemoryFlags::all(),
+            };
+            let texture =
+                self.handler
+                    .device
+                    .as_hal::<wgpu::wgc::api::Metal, _, _>(|hdevice| {
+                        hdevice.map(|hdevice|  {
+                            use objc::*;
+                            objc::msg_send![hdevice.raw_device().lock().as_ref(), newTextureWithDescriptor:desc
+                                                                       iosurface:io_surface
+                                                                           plane:0]
+                        })
+                    }).unwrap();
+            self.handler
+                .device
+                .create_texture_from_hal::<wgpu::wgc::api::Metal>(texture, &texture_desc)
         };
         //let dst_texture = self
         //    .handler
@@ -438,7 +474,7 @@ impl ImplRenderHandler for RenderHandlerBuilder {
 }
 
 thread_local! {
-    pub static TEXTURE: RefCell<Option<wgpu::BindGroup>> = const { RefCell::new(None) };
+    pub static TEXTURE: RefCell<Option<wgpu::BindGroup>> = RefCell::new(None);
 }
 
 pub(crate) struct ClientBuilder {

--- a/examples/osr/src/webrender.rs
+++ b/examples/osr/src/webrender.rs
@@ -5,11 +5,9 @@ use cef::{
     *,
 };
 use cef::{ImplRequestContextHandler, RequestContextHandler, WrapRequestContextHandler};
-use metal::NSObject;
-use objc::msg_send;
 use std::cell::RefCell;
 use std::ptr::null_mut;
-use wgpu::{Extent3d, TextureDescriptor, TextureDimension, TextureUsages, hal::Device};
+use wgpu::{Extent3d, TextureDescriptor, TextureDimension, TextureUsages};
 
 #[derive(Clone)]
 pub struct OsrApp {}
@@ -351,17 +349,7 @@ impl ImplRenderHandler for RenderHandlerBuilder {
             else {
                 return;
             };
-            //let desc = wgpu::hal::TextureDescriptor {
-            //    mip_level_count: texture_desc.mip_level_count,
-            //    view_formats: vec![],
-            //    sample_count: texture_desc.sample_count,
-            //    usage: wgpu::TextureUses::STORAGE_READ_ONLY,
-            //    label: Some("Cef Texture"),
-            //    dimension: texture_desc.dimension,
-            //    format: texture_desc.format,
-            //    size: texture_desc.size,
-            //    memory_flags: wgpu::hal::MemoryFlags::all(),
-            //};
+
             let metal_desc = metal::TextureDescriptor::new();
             metal_desc.set_width(texture_desc.size.width as _);
             metal_desc.set_height(texture_desc.size.height as _);
@@ -388,9 +376,21 @@ impl ImplRenderHandler for RenderHandlerBuilder {
                                                                            plane:0]
                         })
                     }).unwrap();
+            let hal_tex = <wgpu::wgc::api::Metal as wgpu::hal::Api>::Device::texture_from_raw(
+                texture,
+                texture_desc.format,
+                metal::MTLTextureType::D2,
+                texture_desc.array_layer_count(),
+                texture_desc.mip_level_count,
+                wgpu::hal::CopyExtent {
+                    width: texture_desc.size.width,
+                    height: texture_desc.size.height,
+                    depth: texture_desc.array_layer_count(),
+                },
+            );
             self.handler
                 .device
-                .create_texture_from_hal::<wgpu::wgc::api::Metal>(texture, &texture_desc)
+                .create_texture_from_hal::<wgpu::wgc::api::Metal>(hal_tex, &texture_desc)
         };
         //let dst_texture = self
         //    .handler


### PR DESCRIPTION
<img width="811" height="630" alt="image" src="https://github.com/user-attachments/assets/3c9fd29f-02a9-4cec-8ac1-48dd469d3214" />

Test steps:
1. cargo r --bin bundle_cefsimple --no-default-features
2. cargo b --manifest-path=examples/osr/Cargo.toml
3. cp target/debug/cef-osr target/debug/cefsimple.app/Contents/MacOS/cefsimple
4. target/debug/cefsimple.app/Contents/MacOS/cefsimple

(We need cefsimple to create a osx app bundle)