### PR TITLE
Don't use &mut impl Trait as mutable arguments

### DIFF
--- a/sys/wrapper.h
+++ b/sys/wrapper.h
@@ -7,6 +7,7 @@
 #endif
 
 #include "include/cef_api_hash.h"
+#include "include/cef_version.h"
 
 #include "include/capi/cef_base_capi.h"
 

--- a/update-bindings/src/parse_tree.rs
+++ b/update-bindings/src/parse_tree.rs
@@ -1344,16 +1344,10 @@ impl ModifiedType {
                         } else {
                             quote! { Option<&impl #impl_trait> }
                         }),
-                        [TypeModifier::MutPtr] => Some(if is_sealed {
-                            quote! { Option<&mut #name> }
-                        } else {
-                            quote! { Option<&mut impl #impl_trait> }
-                        }),
-                        [TypeModifier::MutPtr, TypeModifier::MutPtr] => Some(if is_sealed {
-                            quote! { Option<&mut Option<#name>> }
-                        } else {
-                            quote! { Option<&mut Option<impl #impl_trait>> }
-                        }),
+                        [TypeModifier::MutPtr] => Some(quote! { Option<&mut #name> }),
+                        [TypeModifier::MutPtr, TypeModifier::MutPtr] => {
+                            Some(quote! { Option<&mut Option<#name>> })
+                        }
                         [TypeModifier::Slice] => Some(if is_sealed {
                             quote! { Option<&[Option<#name>]> }
                         } else {

--- a/update-bindings/src/parse_tree.rs
+++ b/update-bindings/src/parse_tree.rs
@@ -436,16 +436,7 @@ impl SignatureRef<'_> {
                         match modifiers {
                             [TypeModifier::MutPtr, TypeModifier::MutPtr] => {
                                 Some(quote! {
-                                    let mut ptr = std::ptr::null_mut();
-                                    let #name = #name
-                                        .map(|arg| {
-                                            if let Some(arg) = arg.as_mut() {
-                                                arg.add_ref();
-                                                ptr = arg.get_raw();
-                                            }
-                                            std::ptr::from_mut(&mut ptr)
-                                        })
-                                        .unwrap_or(std::ptr::null_mut());
+                                    let #name = #name.map(|arg| std::ptr::from_mut(arg)).unwrap_or(std::ptr::null_mut());
                                 })
                             }
                             _ => {
@@ -827,14 +818,7 @@ impl SignatureRef<'_> {
                                         let #arg_name = #arg_name.as_mut();
                                     }),
                                     [TypeModifier::MutPtr, TypeModifier::MutPtr] => Some(quote! {
-                                        let mut #arg_name = unsafe { #arg_name.as_mut() }.and_then(|ptr| {
-                                            if ptr.is_null() {
-                                                None
-                                            } else {
-                                                Some(#name(unsafe { RefGuard::from_raw(*ptr) }))
-                                            }
-                                        });
-                                        let #arg_name = Some(&mut #arg_name);
+                                        let #arg_name = unsafe { #arg_name.as_mut() };
                                     }),
                                     _ => None,
                                 }
@@ -1346,7 +1330,7 @@ impl ModifiedType {
                         }),
                         [TypeModifier::MutPtr] => Some(quote! { Option<&mut #name> }),
                         [TypeModifier::MutPtr, TypeModifier::MutPtr] => {
-                            Some(quote! { Option<&mut Option<#name>> })
+                            Some(quote! { Option<&mut *mut #elem> })
                         }
                         [TypeModifier::Slice] => Some(if is_sealed {
                             quote! { Option<&[Option<#name>]> }


### PR DESCRIPTION
Some apis like [on_before_popup](https://docs.rs/cef/latest/cef/struct.LifeSpanHandler.html#method.on_before_popup) expects users to change the argument from cef, but `&mut impl Trait` will stop them as the concrete type is unknown inside the api.
https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=024bc42fafad9d5519d1085090b90a29

And we cannot deref the `*mut *mut ptr` which makes the argument unassignable at rust side.

Fixes #173 