### PR TITLE
feat: Allow to download CEF binaries with custom base url 

### DIFF
--- a/get-latest/src/main.rs
+++ b/get-latest/src/main.rs
@@ -4,7 +4,9 @@
 extern crate thiserror;
 
 use clap::Parser;
-use download_cef::{CefIndex, Channel, LINUX_TARGETS, MACOS_TARGETS, WINDOWS_TARGETS};
+use download_cef::{
+    CefIndex, Channel, DEFAULT_CDN_URL, LINUX_TARGETS, MACOS_TARGETS, WINDOWS_TARGETS,
+};
 use git_cliff::args::*;
 use regex::Regex;
 use semver::{BuildMetadata, Version};
@@ -54,8 +56,9 @@ fn main() -> Result<()> {
 
     let args = Args::parse();
     let channel = args.channel;
+    let url = std::env::var("CEF_DOWNLOAD_URL").unwrap_or(DEFAULT_CDN_URL.into());
 
-    let index = CefIndex::download()?;
+    let index = CefIndex::download(url.as_str())?;
     let latest_versions: Vec<_> = LINUX_TARGETS
         .iter()
         .chain(MACOS_TARGETS.iter())

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -1,12 +1,13 @@
 #[cfg(not(feature = "dox"))]
 fn main() -> anyhow::Result<()> {
-    use download_cef::{CefIndex, OsAndArch};
+    use download_cef::{CefIndex, OsAndArch, DEFAULT_CDN_URL};
     use std::{env, fs, path::PathBuf};
 
     println!("cargo::rerun-if-changed=build.rs");
 
     let target = env::var("TARGET")?;
     let os_arch = OsAndArch::try_from(target.as_str())?;
+    let url = std::env::var("CEF_DOWNLOAD_URL").unwrap_or(DEFAULT_CDN_URL.into());
 
     println!("cargo::rerun-if-env-changed=FLATPAK");
     println!("cargo::rerun-if-env-changed=CEF_PATH");
@@ -28,11 +29,11 @@ fn main() -> anyhow::Result<()> {
 
             if !fs::exists(&cef_dir)? {
                 let cef_version = download_cef::default_version(&env::var("CARGO_PKG_VERSION")?);
-                let index = CefIndex::download()?;
+                let index = CefIndex::download(url.as_str())?;
                 let platform = index.platform(&target)?;
                 let version = platform.version(&cef_version)?;
 
-                let archive = version.download_archive(&out_dir, false)?;
+                let archive = version.download_archive(url.as_str(), &out_dir, false)?;
                 let extracted_dir =
                     download_cef::extract_target_archive(&target, &archive, &out_dir, false)?;
                 if extracted_dir != cef_dir {

--- a/update-bindings/src/main.rs
+++ b/update-bindings/src/main.rs
@@ -4,7 +4,7 @@
 extern crate thiserror;
 
 use clap::Parser;
-use download_cef::DEFAULT_TARGET;
+use download_cef::{DEFAULT_CDN_URL, DEFAULT_TARGET};
 use std::{fs, io::Read, path::Path, sync::OnceLock};
 
 #[derive(Debug, Error)]
@@ -54,10 +54,11 @@ struct Args {
 fn main() -> Result<()> {
     let args = Args::parse();
     let target = args.target.as_str();
+    let url = std::env::var("CEF_DOWNLOAD_URL").unwrap_or(DEFAULT_CDN_URL.into());
 
     if args.bindgen {
         if args.download {
-            let _ = upgrade::download(target, args.version.as_str());
+            let _ = upgrade::download(url.as_str(), target, args.version.as_str());
         }
 
         upgrade::sys_bindgen(target)?;

--- a/update-bindings/src/upgrade.rs
+++ b/update-bindings/src/upgrade.rs
@@ -18,11 +18,12 @@ const TARGETS: &[&str] = &[
     "arm-unknown-linux-gnueabi",
 ];
 
-pub fn download(target: &str, version: &str) -> PathBuf {
+pub fn download(url: &str, target: &str, version: &str) -> PathBuf {
     assert!(TARGETS.contains(&target), "unsupported target {target}");
 
-    let archive = download_cef::download_target_archive(target, version, dirs::get_out_dir(), true)
-        .expect("download failed");
+    let archive =
+        download_cef::download_target_archive(url, target, version, dirs::get_out_dir(), true)
+            .expect("download failed");
 
     download_cef::extract_target_archive(target, &archive, dirs::get_out_dir(), true)
         .expect("extraction failed")


### PR DESCRIPTION
In many companies, internet access is impossible. In order to download binaries from a company repository (like Artifactory by example), using an environment variable (CEF_DOWNLOAD_URL) rather than a constant is interesting.