### PR TITLE
feat: add --mirror-url cli args

### DIFF
--- a/sys/build.rs
+++ b/sys/build.rs
@@ -1,13 +1,12 @@
 #[cfg(not(feature = "dox"))]
 fn main() -> anyhow::Result<()> {
-    use download_cef::{CefIndex, OsAndArch, DEFAULT_CDN_URL};
+    use download_cef::{CefIndex, OsAndArch};
     use std::{env, fs, path::PathBuf};
 
     println!("cargo::rerun-if-changed=build.rs");
 
     let target = env::var("TARGET")?;
     let os_arch = OsAndArch::try_from(target.as_str())?;
-    let url = std::env::var("CEF_DOWNLOAD_URL").unwrap_or(DEFAULT_CDN_URL.into());
 
     println!("cargo::rerun-if-env-changed=FLATPAK");
     println!("cargo::rerun-if-env-changed=CEF_PATH");
@@ -29,11 +28,11 @@ fn main() -> anyhow::Result<()> {
 
             if !fs::exists(&cef_dir)? {
                 let cef_version = download_cef::default_version(&env::var("CARGO_PKG_VERSION")?);
-                let index = CefIndex::download(url.as_str())?;
+                let index = CefIndex::download()?;
                 let platform = index.platform(&target)?;
                 let version = platform.version(&cef_version)?;
 
-                let archive = version.download_archive(url.as_str(), &out_dir, false)?;
+                let archive = version.download_archive(&out_dir, false)?;
                 let extracted_dir =
                     download_cef::extract_target_archive(&target, &archive, &out_dir, false)?;
                 if extracted_dir != cef_dir {

--- a/update-bindings/src/main.rs
+++ b/update-bindings/src/main.rs
@@ -4,7 +4,7 @@
 extern crate thiserror;
 
 use clap::Parser;
-use download_cef::{DEFAULT_CDN_URL, DEFAULT_TARGET};
+use download_cef::DEFAULT_TARGET;
 use std::{fs, io::Read, path::Path, sync::OnceLock};
 
 #[derive(Debug, Error)]
@@ -38,6 +38,13 @@ fn default_version() -> &'static str {
         .as_str()
 }
 
+fn default_download_url() -> &'static str {
+    static DEFAULT_DOWNLOAD_URL: OnceLock<String> = OnceLock::new();
+    DEFAULT_DOWNLOAD_URL
+        .get_or_init(|| download_cef::default_download_url())
+        .as_str()
+}
+
 #[derive(Parser, Debug)]
 #[command(about, long_about = None)]
 struct Args {
@@ -49,16 +56,17 @@ struct Args {
     target: String,
     #[arg(short, long, default_value = default_version())]
     version: String,
+    #[arg(short, long, default_value = default_download_url())]
+    mirror_url: String,
 }
 
 fn main() -> Result<()> {
     let args = Args::parse();
     let target = args.target.as_str();
-    let url = std::env::var("CEF_DOWNLOAD_URL").unwrap_or(DEFAULT_CDN_URL.into());
 
     if args.bindgen {
         if args.download {
-            let _ = upgrade::download(url.as_str(), target, args.version.as_str());
+            let _ = upgrade::download(args.mirror_url.as_str(), target, args.version.as_str());
         }
 
         upgrade::sys_bindgen(target)?;

--- a/update-bindings/src/upgrade.rs
+++ b/update-bindings/src/upgrade.rs
@@ -22,7 +22,7 @@ pub fn download(url: &str, target: &str, version: &str) -> PathBuf {
     assert!(TARGETS.contains(&target), "unsupported target {target}");
 
     let archive =
-        download_cef::download_target_archive(url, target, version, dirs::get_out_dir(), true)
+        download_cef::download_target_archive_from(url, target, version, dirs::get_out_dir(), true)
             .expect("download failed");
 
     download_cef::extract_target_archive(target, &archive, dirs::get_out_dir(), true)


### PR DESCRIPTION
This should also make `download-cef` API compatible since the functions that override the URL all have `..._from` appended to the name.