### PR TITLE
feat: debug scalar types

### DIFF
--- a/cef/src/string.rs
+++ b/cef/src/string.rs
@@ -163,6 +163,12 @@ impl Drop for CefStringUserfreeUtf16 {
     }
 }
 
+impl Debug for CefStringUtf16 {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", CefStringUtf8::from(self))
+    }
+}
+
 #[derive(Clone, Default)]
 pub struct CefStringUserfreeWide(UserFreeData<_cef_string_wide_t>);
 

--- a/examples/osr/src/main.rs
+++ b/examples/osr/src/main.rs
@@ -47,7 +47,13 @@ impl State {
             .await
             .unwrap();
         let (device, queue) = adapter
-            .request_device(&wgpu::DeviceDescriptor::default())
+            .request_device(&wgpu::DeviceDescriptor {
+                required_limits: wgpu::Limits {
+                    max_non_sampler_bindings: 2048,
+                    ..Default::default()
+                },
+                ..Default::default()
+            })
             .await
             .unwrap();
 

--- a/update-bindings/src/parse_tree.rs
+++ b/update-bindings/src/parse_tree.rs
@@ -3316,7 +3316,7 @@ fn make_my_struct() -> {rust_name} {{
             };
 
             let wrapper = quote! {
-                #[derive(Clone)]
+                #[derive(Clone, Debug)]
                 pub struct #rust_name {
                     #(#fields_decl)*
                 }


### PR DESCRIPTION
Add `Debug` for non-Rc types like `Settings`/`cef::Rect`, they are aggregated with scalar types (c_int, bool).

And user should not use the default `wgpu::Limits` config(1_000_000) from wgpu, which is firefox specified and resulting huge ram usage with integrated gpu on Windows.(confirmed by wgpu contributor)