### PR TITLE
fix: interface cast

### DIFF
--- a/.github/workflows/bindings-changed.yml
+++ b/.github/workflows/bindings-changed.yml
@@ -2,6 +2,8 @@ name: Bindings changed
 
 on:
   push:
+    branches:
+      - dev
     paths:
       - Cargo.toml
       - sys/wrapper.h
@@ -13,4 +15,4 @@ jobs:
   update-bindings:
     uses: ./.github/workflows/update-bindings.yml
     with:
-      branch: "fix/interface-cast"
+      branch: "dev"

--- a/.github/workflows/bindings-changed.yml
+++ b/.github/workflows/bindings-changed.yml
@@ -2,8 +2,6 @@ name: Bindings changed
 
 on:
   push:
-    branches:
-      - dev
     paths:
       - Cargo.toml
       - sys/wrapper.h
@@ -15,4 +13,4 @@ jobs:
   update-bindings:
     uses: ./.github/workflows/update-bindings.yml
     with:
-      branch: "dev"
+      branch: "fix/interface-cast"

--- a/cef/src/bindings/aarch64_apple_darwin.rs
+++ b/cef/src/bindings/aarch64_apple_darwin.rs
@@ -35891,7 +35891,7 @@ pub trait ImplButtonDelegate: ImplViewDelegate {
     #[doc = "See [`_cef_button_delegate_t::on_button_state_changed`] for more documentation."]
     fn on_button_state_changed(&self, button: Option<&mut Button>) {}
     fn init_methods(object: &mut _cef_button_delegate_t) {
-        impl_cef_view_delegate_t::init_methods::<Self>(&mut object.base);
+        impl_cef_button_delegate_t::bridge_cef_view_delegate_t::init_methods::<Self>(object);
         impl_cef_button_delegate_t::init_methods::<Self>(object);
     }
     fn get_raw(&self) -> *mut _cef_button_delegate_t {
@@ -35928,6 +35928,179 @@ mod impl_cef_button_delegate_t {
             unsafe { arg_button.as_mut() }.map(|arg| Button(unsafe { RefGuard::from_raw(arg) }));
         let arg_button = arg_button.as_mut();
         ImplButtonDelegate::on_button_state_changed(&arg_self_.interface, arg_button)
+    }
+    pub(crate) mod bridge_cef_view_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplButtonDelegate>(object: &mut _cef_button_delegate_t) {
+            object.base.get_preferred_size = Some(get_preferred_size::<I>);
+            object.base.get_minimum_size = Some(get_minimum_size::<I>);
+            object.base.get_maximum_size = Some(get_maximum_size::<I>);
+            object.base.get_height_for_width = Some(get_height_for_width::<I>);
+            object.base.on_parent_view_changed = Some(on_parent_view_changed::<I>);
+            object.base.on_child_view_changed = Some(on_child_view_changed::<I>);
+            object.base.on_window_changed = Some(on_window_changed::<I>);
+            object.base.on_layout_changed = Some(on_layout_changed::<I>);
+            object.base.on_focus = Some(on_focus::<I>);
+            object.base.on_blur = Some(on_blur::<I>);
+            object.base.on_theme_changed = Some(on_theme_changed::<I>);
+        }
+        extern "C" fn get_preferred_size<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::preferred_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_minimum_size<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::minimum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_maximum_size<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::maximum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_height_for_width<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            width: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int {
+            let (arg_self_, arg_view, arg_width) = (self_, view, width);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_width = arg_width.into_raw();
+            ImplViewDelegate::height_for_width(&arg_self_.interface, arg_view, arg_width)
+        }
+        extern "C" fn on_parent_view_changed<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            parent: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_parent) = (self_, view, added, parent);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_parent =
+                unsafe { arg_parent.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_parent = arg_parent.as_mut();
+            ImplViewDelegate::on_parent_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_parent,
+            )
+        }
+        extern "C" fn on_child_view_changed<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            child: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_child) = (self_, view, added, child);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_child =
+                unsafe { arg_child.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_child = arg_child.as_mut();
+            ImplViewDelegate::on_child_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_child,
+            )
+        }
+        extern "C" fn on_window_changed<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+        ) {
+            let (arg_self_, arg_view, arg_added) = (self_, view, added);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            ImplViewDelegate::on_window_changed(&arg_self_.interface, arg_view, arg_added)
+        }
+        extern "C" fn on_layout_changed<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            new_bounds: *const _cef_rect_t,
+        ) {
+            let (arg_self_, arg_view, arg_new_bounds) = (self_, view, new_bounds);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_new_bounds = if arg_new_bounds.is_null() {
+                None
+            } else {
+                Some(WrapParamRef::<Rect, _>::from(arg_new_bounds))
+            };
+            let arg_new_bounds = arg_new_bounds.as_ref().map(|arg| arg.as_ref());
+            ImplViewDelegate::on_layout_changed(&arg_self_.interface, arg_view, arg_new_bounds)
+        }
+        extern "C" fn on_focus<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_focus(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_blur<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_blur(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_theme_changed<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_theme_changed(&arg_self_.interface, arg_view)
+        }
     }
 }
 impl ImplViewDelegate for ButtonDelegate {
@@ -36549,8 +36722,8 @@ pub trait ImplMenuButtonDelegate: ImplButtonDelegate {
     ) {
     }
     fn init_methods(object: &mut _cef_menu_button_delegate_t) {
-        impl_cef_view_delegate_t::init_methods::<Self>(&mut object.base.base);
-        impl_cef_button_delegate_t::init_methods::<Self>(&mut object.base);
+        impl_cef_menu_button_delegate_t::bridge_cef_view_delegate_t::init_methods::<Self>(object);
+        impl_cef_menu_button_delegate_t::bridge_cef_button_delegate_t::init_methods::<Self>(object);
         impl_cef_menu_button_delegate_t::init_methods::<Self>(object);
     }
     fn get_raw(&self) -> *mut _cef_menu_button_delegate_t {
@@ -36592,6 +36765,208 @@ mod impl_cef_menu_button_delegate_t {
             arg_screen_point,
             arg_button_pressed_lock,
         )
+    }
+    pub(crate) mod bridge_cef_view_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplMenuButtonDelegate>(object: &mut _cef_menu_button_delegate_t) {
+            object.base.base.get_preferred_size = Some(get_preferred_size::<I>);
+            object.base.base.get_minimum_size = Some(get_minimum_size::<I>);
+            object.base.base.get_maximum_size = Some(get_maximum_size::<I>);
+            object.base.base.get_height_for_width = Some(get_height_for_width::<I>);
+            object.base.base.on_parent_view_changed = Some(on_parent_view_changed::<I>);
+            object.base.base.on_child_view_changed = Some(on_child_view_changed::<I>);
+            object.base.base.on_window_changed = Some(on_window_changed::<I>);
+            object.base.base.on_layout_changed = Some(on_layout_changed::<I>);
+            object.base.base.on_focus = Some(on_focus::<I>);
+            object.base.base.on_blur = Some(on_blur::<I>);
+            object.base.base.on_theme_changed = Some(on_theme_changed::<I>);
+        }
+        extern "C" fn get_preferred_size<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::preferred_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_minimum_size<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::minimum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_maximum_size<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::maximum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_height_for_width<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            width: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int {
+            let (arg_self_, arg_view, arg_width) = (self_, view, width);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_width = arg_width.into_raw();
+            ImplViewDelegate::height_for_width(&arg_self_.interface, arg_view, arg_width)
+        }
+        extern "C" fn on_parent_view_changed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            parent: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_parent) = (self_, view, added, parent);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_parent =
+                unsafe { arg_parent.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_parent = arg_parent.as_mut();
+            ImplViewDelegate::on_parent_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_parent,
+            )
+        }
+        extern "C" fn on_child_view_changed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            child: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_child) = (self_, view, added, child);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_child =
+                unsafe { arg_child.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_child = arg_child.as_mut();
+            ImplViewDelegate::on_child_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_child,
+            )
+        }
+        extern "C" fn on_window_changed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+        ) {
+            let (arg_self_, arg_view, arg_added) = (self_, view, added);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            ImplViewDelegate::on_window_changed(&arg_self_.interface, arg_view, arg_added)
+        }
+        extern "C" fn on_layout_changed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            new_bounds: *const _cef_rect_t,
+        ) {
+            let (arg_self_, arg_view, arg_new_bounds) = (self_, view, new_bounds);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_new_bounds = if arg_new_bounds.is_null() {
+                None
+            } else {
+                Some(WrapParamRef::<Rect, _>::from(arg_new_bounds))
+            };
+            let arg_new_bounds = arg_new_bounds.as_ref().map(|arg| arg.as_ref());
+            ImplViewDelegate::on_layout_changed(&arg_self_.interface, arg_view, arg_new_bounds)
+        }
+        extern "C" fn on_focus<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_focus(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_blur<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_blur(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_theme_changed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_theme_changed(&arg_self_.interface, arg_view)
+        }
+    }
+    pub(crate) mod bridge_cef_button_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplMenuButtonDelegate>(object: &mut _cef_menu_button_delegate_t) {
+            object.base.on_button_pressed = Some(on_button_pressed::<I>);
+            object.base.on_button_state_changed = Some(on_button_state_changed::<I>);
+        }
+        extern "C" fn on_button_pressed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_button_delegate_t,
+            button: *mut _cef_button_t,
+        ) {
+            let (arg_self_, arg_button) = (self_, button);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_button = unsafe { arg_button.as_mut() }
+                .map(|arg| Button(unsafe { RefGuard::from_raw(arg) }));
+            let arg_button = arg_button.as_mut();
+            ImplButtonDelegate::on_button_pressed(&arg_self_.interface, arg_button)
+        }
+        extern "C" fn on_button_state_changed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_button_delegate_t,
+            button: *mut _cef_button_t,
+        ) {
+            let (arg_self_, arg_button) = (self_, button);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_button = unsafe { arg_button.as_mut() }
+                .map(|arg| Button(unsafe { RefGuard::from_raw(arg) }));
+            let arg_button = arg_button.as_mut();
+            ImplButtonDelegate::on_button_state_changed(&arg_self_.interface, arg_button)
+        }
     }
 }
 impl ImplViewDelegate for MenuButtonDelegate {
@@ -37118,7 +37493,7 @@ pub trait ImplTextfieldDelegate: ImplViewDelegate {
     #[doc = "See [`_cef_textfield_delegate_t::on_after_user_action`] for more documentation."]
     fn on_after_user_action(&self, textfield: Option<&mut Textfield>) {}
     fn init_methods(object: &mut _cef_textfield_delegate_t) {
-        impl_cef_view_delegate_t::init_methods::<Self>(&mut object.base);
+        impl_cef_textfield_delegate_t::bridge_cef_view_delegate_t::init_methods::<Self>(object);
         impl_cef_textfield_delegate_t::init_methods::<Self>(object);
     }
     fn get_raw(&self) -> *mut _cef_textfield_delegate_t {
@@ -37162,6 +37537,179 @@ mod impl_cef_textfield_delegate_t {
             .map(|arg| Textfield(unsafe { RefGuard::from_raw(arg) }));
         let arg_textfield = arg_textfield.as_mut();
         ImplTextfieldDelegate::on_after_user_action(&arg_self_.interface, arg_textfield)
+    }
+    pub(crate) mod bridge_cef_view_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplTextfieldDelegate>(object: &mut _cef_textfield_delegate_t) {
+            object.base.get_preferred_size = Some(get_preferred_size::<I>);
+            object.base.get_minimum_size = Some(get_minimum_size::<I>);
+            object.base.get_maximum_size = Some(get_maximum_size::<I>);
+            object.base.get_height_for_width = Some(get_height_for_width::<I>);
+            object.base.on_parent_view_changed = Some(on_parent_view_changed::<I>);
+            object.base.on_child_view_changed = Some(on_child_view_changed::<I>);
+            object.base.on_window_changed = Some(on_window_changed::<I>);
+            object.base.on_layout_changed = Some(on_layout_changed::<I>);
+            object.base.on_focus = Some(on_focus::<I>);
+            object.base.on_blur = Some(on_blur::<I>);
+            object.base.on_theme_changed = Some(on_theme_changed::<I>);
+        }
+        extern "C" fn get_preferred_size<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::preferred_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_minimum_size<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::minimum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_maximum_size<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::maximum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_height_for_width<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            width: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int {
+            let (arg_self_, arg_view, arg_width) = (self_, view, width);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_width = arg_width.into_raw();
+            ImplViewDelegate::height_for_width(&arg_self_.interface, arg_view, arg_width)
+        }
+        extern "C" fn on_parent_view_changed<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            parent: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_parent) = (self_, view, added, parent);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_parent =
+                unsafe { arg_parent.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_parent = arg_parent.as_mut();
+            ImplViewDelegate::on_parent_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_parent,
+            )
+        }
+        extern "C" fn on_child_view_changed<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            child: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_child) = (self_, view, added, child);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_child =
+                unsafe { arg_child.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_child = arg_child.as_mut();
+            ImplViewDelegate::on_child_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_child,
+            )
+        }
+        extern "C" fn on_window_changed<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+        ) {
+            let (arg_self_, arg_view, arg_added) = (self_, view, added);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            ImplViewDelegate::on_window_changed(&arg_self_.interface, arg_view, arg_added)
+        }
+        extern "C" fn on_layout_changed<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            new_bounds: *const _cef_rect_t,
+        ) {
+            let (arg_self_, arg_view, arg_new_bounds) = (self_, view, new_bounds);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_new_bounds = if arg_new_bounds.is_null() {
+                None
+            } else {
+                Some(WrapParamRef::<Rect, _>::from(arg_new_bounds))
+            };
+            let arg_new_bounds = arg_new_bounds.as_ref().map(|arg| arg.as_ref());
+            ImplViewDelegate::on_layout_changed(&arg_self_.interface, arg_view, arg_new_bounds)
+        }
+        extern "C" fn on_focus<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_focus(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_blur<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_blur(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_theme_changed<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_theme_changed(&arg_self_.interface, arg_view)
+        }
     }
 }
 impl ImplViewDelegate for TextfieldDelegate {
@@ -38031,7 +38579,7 @@ pub trait ImplBrowserViewDelegate: ImplViewDelegate {
         Default::default()
     }
     fn init_methods(object: &mut _cef_browser_view_delegate_t) {
-        impl_cef_view_delegate_t::init_methods::<Self>(&mut object.base);
+        impl_cef_browser_view_delegate_t::bridge_cef_view_delegate_t::init_methods::<Self>(object);
         impl_cef_browser_view_delegate_t::init_methods::<Self>(object);
     }
     fn get_raw(&self) -> *mut _cef_browser_view_delegate_t {
@@ -38216,6 +38764,179 @@ mod impl_cef_browser_view_delegate_t {
             &arg_self_.interface,
             arg_browser_view,
         )
+    }
+    pub(crate) mod bridge_cef_view_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplBrowserViewDelegate>(object: &mut _cef_browser_view_delegate_t) {
+            object.base.get_preferred_size = Some(get_preferred_size::<I>);
+            object.base.get_minimum_size = Some(get_minimum_size::<I>);
+            object.base.get_maximum_size = Some(get_maximum_size::<I>);
+            object.base.get_height_for_width = Some(get_height_for_width::<I>);
+            object.base.on_parent_view_changed = Some(on_parent_view_changed::<I>);
+            object.base.on_child_view_changed = Some(on_child_view_changed::<I>);
+            object.base.on_window_changed = Some(on_window_changed::<I>);
+            object.base.on_layout_changed = Some(on_layout_changed::<I>);
+            object.base.on_focus = Some(on_focus::<I>);
+            object.base.on_blur = Some(on_blur::<I>);
+            object.base.on_theme_changed = Some(on_theme_changed::<I>);
+        }
+        extern "C" fn get_preferred_size<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::preferred_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_minimum_size<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::minimum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_maximum_size<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::maximum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_height_for_width<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            width: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int {
+            let (arg_self_, arg_view, arg_width) = (self_, view, width);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_width = arg_width.into_raw();
+            ImplViewDelegate::height_for_width(&arg_self_.interface, arg_view, arg_width)
+        }
+        extern "C" fn on_parent_view_changed<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            parent: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_parent) = (self_, view, added, parent);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_parent =
+                unsafe { arg_parent.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_parent = arg_parent.as_mut();
+            ImplViewDelegate::on_parent_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_parent,
+            )
+        }
+        extern "C" fn on_child_view_changed<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            child: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_child) = (self_, view, added, child);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_child =
+                unsafe { arg_child.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_child = arg_child.as_mut();
+            ImplViewDelegate::on_child_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_child,
+            )
+        }
+        extern "C" fn on_window_changed<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+        ) {
+            let (arg_self_, arg_view, arg_added) = (self_, view, added);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            ImplViewDelegate::on_window_changed(&arg_self_.interface, arg_view, arg_added)
+        }
+        extern "C" fn on_layout_changed<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            new_bounds: *const _cef_rect_t,
+        ) {
+            let (arg_self_, arg_view, arg_new_bounds) = (self_, view, new_bounds);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_new_bounds = if arg_new_bounds.is_null() {
+                None
+            } else {
+                Some(WrapParamRef::<Rect, _>::from(arg_new_bounds))
+            };
+            let arg_new_bounds = arg_new_bounds.as_ref().map(|arg| arg.as_ref());
+            ImplViewDelegate::on_layout_changed(&arg_self_.interface, arg_view, arg_new_bounds)
+        }
+        extern "C" fn on_focus<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_focus(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_blur<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_blur(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_theme_changed<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_theme_changed(&arg_self_.interface, arg_view)
+        }
     }
 }
 impl ImplViewDelegate for BrowserViewDelegate {
@@ -39648,7 +40369,7 @@ pub trait WrapPanelDelegate: ImplPanelDelegate {
 }
 pub trait ImplPanelDelegate: ImplViewDelegate {
     fn init_methods(object: &mut _cef_panel_delegate_t) {
-        impl_cef_view_delegate_t::init_methods::<Self>(&mut object.base);
+        impl_cef_panel_delegate_t::bridge_cef_view_delegate_t::init_methods::<Self>(object);
         impl_cef_panel_delegate_t::init_methods::<Self>(object);
     }
     fn get_raw(&self) -> *mut _cef_panel_delegate_t {
@@ -39661,6 +40382,179 @@ macro_rules ! wrap_panel_delegate { ($ vis : vis struct $ name : ident ; impl Vi
 mod impl_cef_panel_delegate_t {
     use super::*;
     pub fn init_methods<I: ImplPanelDelegate>(object: &mut _cef_panel_delegate_t) {}
+    pub(crate) mod bridge_cef_view_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplPanelDelegate>(object: &mut _cef_panel_delegate_t) {
+            object.base.get_preferred_size = Some(get_preferred_size::<I>);
+            object.base.get_minimum_size = Some(get_minimum_size::<I>);
+            object.base.get_maximum_size = Some(get_maximum_size::<I>);
+            object.base.get_height_for_width = Some(get_height_for_width::<I>);
+            object.base.on_parent_view_changed = Some(on_parent_view_changed::<I>);
+            object.base.on_child_view_changed = Some(on_child_view_changed::<I>);
+            object.base.on_window_changed = Some(on_window_changed::<I>);
+            object.base.on_layout_changed = Some(on_layout_changed::<I>);
+            object.base.on_focus = Some(on_focus::<I>);
+            object.base.on_blur = Some(on_blur::<I>);
+            object.base.on_theme_changed = Some(on_theme_changed::<I>);
+        }
+        extern "C" fn get_preferred_size<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::preferred_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_minimum_size<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::minimum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_maximum_size<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::maximum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_height_for_width<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            width: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int {
+            let (arg_self_, arg_view, arg_width) = (self_, view, width);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_width = arg_width.into_raw();
+            ImplViewDelegate::height_for_width(&arg_self_.interface, arg_view, arg_width)
+        }
+        extern "C" fn on_parent_view_changed<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            parent: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_parent) = (self_, view, added, parent);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_parent =
+                unsafe { arg_parent.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_parent = arg_parent.as_mut();
+            ImplViewDelegate::on_parent_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_parent,
+            )
+        }
+        extern "C" fn on_child_view_changed<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            child: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_child) = (self_, view, added, child);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_child =
+                unsafe { arg_child.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_child = arg_child.as_mut();
+            ImplViewDelegate::on_child_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_child,
+            )
+        }
+        extern "C" fn on_window_changed<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+        ) {
+            let (arg_self_, arg_view, arg_added) = (self_, view, added);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            ImplViewDelegate::on_window_changed(&arg_self_.interface, arg_view, arg_added)
+        }
+        extern "C" fn on_layout_changed<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            new_bounds: *const _cef_rect_t,
+        ) {
+            let (arg_self_, arg_view, arg_new_bounds) = (self_, view, new_bounds);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_new_bounds = if arg_new_bounds.is_null() {
+                None
+            } else {
+                Some(WrapParamRef::<Rect, _>::from(arg_new_bounds))
+            };
+            let arg_new_bounds = arg_new_bounds.as_ref().map(|arg| arg.as_ref());
+            ImplViewDelegate::on_layout_changed(&arg_self_.interface, arg_view, arg_new_bounds)
+        }
+        extern "C" fn on_focus<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_focus(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_blur<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_blur(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_theme_changed<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_theme_changed(&arg_self_.interface, arg_view)
+        }
+    }
 }
 impl ImplViewDelegate for PanelDelegate {
     fn preferred_size(&self, view: Option<&mut View>) -> Size {
@@ -40319,8 +41213,8 @@ pub trait ImplWindowDelegate: ImplPanelDelegate {
         Default::default()
     }
     fn init_methods(object: &mut _cef_window_delegate_t) {
-        impl_cef_view_delegate_t::init_methods::<Self>(&mut object.base.base);
-        impl_cef_panel_delegate_t::init_methods::<Self>(&mut object.base);
+        impl_cef_window_delegate_t::bridge_cef_view_delegate_t::init_methods::<Self>(object);
+        impl_cef_window_delegate_t::bridge_cef_panel_delegate_t::init_methods::<Self>(object);
         impl_cef_window_delegate_t::init_methods::<Self>(object);
     }
     fn get_raw(&self) -> *mut _cef_window_delegate_t {
@@ -40692,6 +41586,183 @@ mod impl_cef_window_delegate_t {
             arg_window,
             arg_properties,
         )
+    }
+    pub(crate) mod bridge_cef_view_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplWindowDelegate>(object: &mut _cef_window_delegate_t) {
+            object.base.base.get_preferred_size = Some(get_preferred_size::<I>);
+            object.base.base.get_minimum_size = Some(get_minimum_size::<I>);
+            object.base.base.get_maximum_size = Some(get_maximum_size::<I>);
+            object.base.base.get_height_for_width = Some(get_height_for_width::<I>);
+            object.base.base.on_parent_view_changed = Some(on_parent_view_changed::<I>);
+            object.base.base.on_child_view_changed = Some(on_child_view_changed::<I>);
+            object.base.base.on_window_changed = Some(on_window_changed::<I>);
+            object.base.base.on_layout_changed = Some(on_layout_changed::<I>);
+            object.base.base.on_focus = Some(on_focus::<I>);
+            object.base.base.on_blur = Some(on_blur::<I>);
+            object.base.base.on_theme_changed = Some(on_theme_changed::<I>);
+        }
+        extern "C" fn get_preferred_size<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::preferred_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_minimum_size<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::minimum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_maximum_size<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::maximum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_height_for_width<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            width: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int {
+            let (arg_self_, arg_view, arg_width) = (self_, view, width);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_width = arg_width.into_raw();
+            ImplViewDelegate::height_for_width(&arg_self_.interface, arg_view, arg_width)
+        }
+        extern "C" fn on_parent_view_changed<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            parent: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_parent) = (self_, view, added, parent);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_parent =
+                unsafe { arg_parent.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_parent = arg_parent.as_mut();
+            ImplViewDelegate::on_parent_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_parent,
+            )
+        }
+        extern "C" fn on_child_view_changed<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            child: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_child) = (self_, view, added, child);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_child =
+                unsafe { arg_child.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_child = arg_child.as_mut();
+            ImplViewDelegate::on_child_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_child,
+            )
+        }
+        extern "C" fn on_window_changed<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+        ) {
+            let (arg_self_, arg_view, arg_added) = (self_, view, added);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            ImplViewDelegate::on_window_changed(&arg_self_.interface, arg_view, arg_added)
+        }
+        extern "C" fn on_layout_changed<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            new_bounds: *const _cef_rect_t,
+        ) {
+            let (arg_self_, arg_view, arg_new_bounds) = (self_, view, new_bounds);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_new_bounds = if arg_new_bounds.is_null() {
+                None
+            } else {
+                Some(WrapParamRef::<Rect, _>::from(arg_new_bounds))
+            };
+            let arg_new_bounds = arg_new_bounds.as_ref().map(|arg| arg.as_ref());
+            ImplViewDelegate::on_layout_changed(&arg_self_.interface, arg_view, arg_new_bounds)
+        }
+        extern "C" fn on_focus<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_focus(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_blur<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_blur(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_theme_changed<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_theme_changed(&arg_self_.interface, arg_view)
+        }
+    }
+    pub(crate) mod bridge_cef_panel_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplWindowDelegate>(object: &mut _cef_window_delegate_t) {}
     }
 }
 impl ImplViewDelegate for WindowDelegate {

--- a/cef/src/bindings/aarch64_pc_windows_msvc.rs
+++ b/cef/src/bindings/aarch64_pc_windows_msvc.rs
@@ -35919,7 +35919,7 @@ pub trait ImplButtonDelegate: ImplViewDelegate {
     #[doc = "See [`_cef_button_delegate_t::on_button_state_changed`] for more documentation."]
     fn on_button_state_changed(&self, button: Option<&mut Button>) {}
     fn init_methods(object: &mut _cef_button_delegate_t) {
-        impl_cef_view_delegate_t::init_methods::<Self>(&mut object.base);
+        impl_cef_button_delegate_t::bridge_cef_view_delegate_t::init_methods::<Self>(object);
         impl_cef_button_delegate_t::init_methods::<Self>(object);
     }
     fn get_raw(&self) -> *mut _cef_button_delegate_t {
@@ -35956,6 +35956,179 @@ mod impl_cef_button_delegate_t {
             unsafe { arg_button.as_mut() }.map(|arg| Button(unsafe { RefGuard::from_raw(arg) }));
         let arg_button = arg_button.as_mut();
         ImplButtonDelegate::on_button_state_changed(&arg_self_.interface, arg_button)
+    }
+    pub(crate) mod bridge_cef_view_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplButtonDelegate>(object: &mut _cef_button_delegate_t) {
+            object.base.get_preferred_size = Some(get_preferred_size::<I>);
+            object.base.get_minimum_size = Some(get_minimum_size::<I>);
+            object.base.get_maximum_size = Some(get_maximum_size::<I>);
+            object.base.get_height_for_width = Some(get_height_for_width::<I>);
+            object.base.on_parent_view_changed = Some(on_parent_view_changed::<I>);
+            object.base.on_child_view_changed = Some(on_child_view_changed::<I>);
+            object.base.on_window_changed = Some(on_window_changed::<I>);
+            object.base.on_layout_changed = Some(on_layout_changed::<I>);
+            object.base.on_focus = Some(on_focus::<I>);
+            object.base.on_blur = Some(on_blur::<I>);
+            object.base.on_theme_changed = Some(on_theme_changed::<I>);
+        }
+        extern "C" fn get_preferred_size<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::preferred_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_minimum_size<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::minimum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_maximum_size<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::maximum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_height_for_width<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            width: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int {
+            let (arg_self_, arg_view, arg_width) = (self_, view, width);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_width = arg_width.into_raw();
+            ImplViewDelegate::height_for_width(&arg_self_.interface, arg_view, arg_width)
+        }
+        extern "C" fn on_parent_view_changed<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            parent: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_parent) = (self_, view, added, parent);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_parent =
+                unsafe { arg_parent.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_parent = arg_parent.as_mut();
+            ImplViewDelegate::on_parent_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_parent,
+            )
+        }
+        extern "C" fn on_child_view_changed<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            child: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_child) = (self_, view, added, child);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_child =
+                unsafe { arg_child.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_child = arg_child.as_mut();
+            ImplViewDelegate::on_child_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_child,
+            )
+        }
+        extern "C" fn on_window_changed<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+        ) {
+            let (arg_self_, arg_view, arg_added) = (self_, view, added);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            ImplViewDelegate::on_window_changed(&arg_self_.interface, arg_view, arg_added)
+        }
+        extern "C" fn on_layout_changed<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            new_bounds: *const _cef_rect_t,
+        ) {
+            let (arg_self_, arg_view, arg_new_bounds) = (self_, view, new_bounds);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_new_bounds = if arg_new_bounds.is_null() {
+                None
+            } else {
+                Some(WrapParamRef::<Rect, _>::from(arg_new_bounds))
+            };
+            let arg_new_bounds = arg_new_bounds.as_ref().map(|arg| arg.as_ref());
+            ImplViewDelegate::on_layout_changed(&arg_self_.interface, arg_view, arg_new_bounds)
+        }
+        extern "C" fn on_focus<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_focus(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_blur<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_blur(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_theme_changed<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_theme_changed(&arg_self_.interface, arg_view)
+        }
     }
 }
 impl ImplViewDelegate for ButtonDelegate {
@@ -36577,8 +36750,8 @@ pub trait ImplMenuButtonDelegate: ImplButtonDelegate {
     ) {
     }
     fn init_methods(object: &mut _cef_menu_button_delegate_t) {
-        impl_cef_view_delegate_t::init_methods::<Self>(&mut object.base.base);
-        impl_cef_button_delegate_t::init_methods::<Self>(&mut object.base);
+        impl_cef_menu_button_delegate_t::bridge_cef_view_delegate_t::init_methods::<Self>(object);
+        impl_cef_menu_button_delegate_t::bridge_cef_button_delegate_t::init_methods::<Self>(object);
         impl_cef_menu_button_delegate_t::init_methods::<Self>(object);
     }
     fn get_raw(&self) -> *mut _cef_menu_button_delegate_t {
@@ -36620,6 +36793,208 @@ mod impl_cef_menu_button_delegate_t {
             arg_screen_point,
             arg_button_pressed_lock,
         )
+    }
+    pub(crate) mod bridge_cef_view_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplMenuButtonDelegate>(object: &mut _cef_menu_button_delegate_t) {
+            object.base.base.get_preferred_size = Some(get_preferred_size::<I>);
+            object.base.base.get_minimum_size = Some(get_minimum_size::<I>);
+            object.base.base.get_maximum_size = Some(get_maximum_size::<I>);
+            object.base.base.get_height_for_width = Some(get_height_for_width::<I>);
+            object.base.base.on_parent_view_changed = Some(on_parent_view_changed::<I>);
+            object.base.base.on_child_view_changed = Some(on_child_view_changed::<I>);
+            object.base.base.on_window_changed = Some(on_window_changed::<I>);
+            object.base.base.on_layout_changed = Some(on_layout_changed::<I>);
+            object.base.base.on_focus = Some(on_focus::<I>);
+            object.base.base.on_blur = Some(on_blur::<I>);
+            object.base.base.on_theme_changed = Some(on_theme_changed::<I>);
+        }
+        extern "C" fn get_preferred_size<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::preferred_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_minimum_size<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::minimum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_maximum_size<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::maximum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_height_for_width<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            width: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int {
+            let (arg_self_, arg_view, arg_width) = (self_, view, width);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_width = arg_width.into_raw();
+            ImplViewDelegate::height_for_width(&arg_self_.interface, arg_view, arg_width)
+        }
+        extern "C" fn on_parent_view_changed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            parent: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_parent) = (self_, view, added, parent);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_parent =
+                unsafe { arg_parent.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_parent = arg_parent.as_mut();
+            ImplViewDelegate::on_parent_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_parent,
+            )
+        }
+        extern "C" fn on_child_view_changed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            child: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_child) = (self_, view, added, child);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_child =
+                unsafe { arg_child.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_child = arg_child.as_mut();
+            ImplViewDelegate::on_child_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_child,
+            )
+        }
+        extern "C" fn on_window_changed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+        ) {
+            let (arg_self_, arg_view, arg_added) = (self_, view, added);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            ImplViewDelegate::on_window_changed(&arg_self_.interface, arg_view, arg_added)
+        }
+        extern "C" fn on_layout_changed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            new_bounds: *const _cef_rect_t,
+        ) {
+            let (arg_self_, arg_view, arg_new_bounds) = (self_, view, new_bounds);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_new_bounds = if arg_new_bounds.is_null() {
+                None
+            } else {
+                Some(WrapParamRef::<Rect, _>::from(arg_new_bounds))
+            };
+            let arg_new_bounds = arg_new_bounds.as_ref().map(|arg| arg.as_ref());
+            ImplViewDelegate::on_layout_changed(&arg_self_.interface, arg_view, arg_new_bounds)
+        }
+        extern "C" fn on_focus<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_focus(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_blur<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_blur(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_theme_changed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_theme_changed(&arg_self_.interface, arg_view)
+        }
+    }
+    pub(crate) mod bridge_cef_button_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplMenuButtonDelegate>(object: &mut _cef_menu_button_delegate_t) {
+            object.base.on_button_pressed = Some(on_button_pressed::<I>);
+            object.base.on_button_state_changed = Some(on_button_state_changed::<I>);
+        }
+        extern "C" fn on_button_pressed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_button_delegate_t,
+            button: *mut _cef_button_t,
+        ) {
+            let (arg_self_, arg_button) = (self_, button);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_button = unsafe { arg_button.as_mut() }
+                .map(|arg| Button(unsafe { RefGuard::from_raw(arg) }));
+            let arg_button = arg_button.as_mut();
+            ImplButtonDelegate::on_button_pressed(&arg_self_.interface, arg_button)
+        }
+        extern "C" fn on_button_state_changed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_button_delegate_t,
+            button: *mut _cef_button_t,
+        ) {
+            let (arg_self_, arg_button) = (self_, button);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_button = unsafe { arg_button.as_mut() }
+                .map(|arg| Button(unsafe { RefGuard::from_raw(arg) }));
+            let arg_button = arg_button.as_mut();
+            ImplButtonDelegate::on_button_state_changed(&arg_self_.interface, arg_button)
+        }
     }
 }
 impl ImplViewDelegate for MenuButtonDelegate {
@@ -37146,7 +37521,7 @@ pub trait ImplTextfieldDelegate: ImplViewDelegate {
     #[doc = "See [`_cef_textfield_delegate_t::on_after_user_action`] for more documentation."]
     fn on_after_user_action(&self, textfield: Option<&mut Textfield>) {}
     fn init_methods(object: &mut _cef_textfield_delegate_t) {
-        impl_cef_view_delegate_t::init_methods::<Self>(&mut object.base);
+        impl_cef_textfield_delegate_t::bridge_cef_view_delegate_t::init_methods::<Self>(object);
         impl_cef_textfield_delegate_t::init_methods::<Self>(object);
     }
     fn get_raw(&self) -> *mut _cef_textfield_delegate_t {
@@ -37190,6 +37565,179 @@ mod impl_cef_textfield_delegate_t {
             .map(|arg| Textfield(unsafe { RefGuard::from_raw(arg) }));
         let arg_textfield = arg_textfield.as_mut();
         ImplTextfieldDelegate::on_after_user_action(&arg_self_.interface, arg_textfield)
+    }
+    pub(crate) mod bridge_cef_view_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplTextfieldDelegate>(object: &mut _cef_textfield_delegate_t) {
+            object.base.get_preferred_size = Some(get_preferred_size::<I>);
+            object.base.get_minimum_size = Some(get_minimum_size::<I>);
+            object.base.get_maximum_size = Some(get_maximum_size::<I>);
+            object.base.get_height_for_width = Some(get_height_for_width::<I>);
+            object.base.on_parent_view_changed = Some(on_parent_view_changed::<I>);
+            object.base.on_child_view_changed = Some(on_child_view_changed::<I>);
+            object.base.on_window_changed = Some(on_window_changed::<I>);
+            object.base.on_layout_changed = Some(on_layout_changed::<I>);
+            object.base.on_focus = Some(on_focus::<I>);
+            object.base.on_blur = Some(on_blur::<I>);
+            object.base.on_theme_changed = Some(on_theme_changed::<I>);
+        }
+        extern "C" fn get_preferred_size<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::preferred_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_minimum_size<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::minimum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_maximum_size<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::maximum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_height_for_width<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            width: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int {
+            let (arg_self_, arg_view, arg_width) = (self_, view, width);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_width = arg_width.into_raw();
+            ImplViewDelegate::height_for_width(&arg_self_.interface, arg_view, arg_width)
+        }
+        extern "C" fn on_parent_view_changed<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            parent: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_parent) = (self_, view, added, parent);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_parent =
+                unsafe { arg_parent.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_parent = arg_parent.as_mut();
+            ImplViewDelegate::on_parent_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_parent,
+            )
+        }
+        extern "C" fn on_child_view_changed<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            child: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_child) = (self_, view, added, child);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_child =
+                unsafe { arg_child.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_child = arg_child.as_mut();
+            ImplViewDelegate::on_child_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_child,
+            )
+        }
+        extern "C" fn on_window_changed<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+        ) {
+            let (arg_self_, arg_view, arg_added) = (self_, view, added);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            ImplViewDelegate::on_window_changed(&arg_self_.interface, arg_view, arg_added)
+        }
+        extern "C" fn on_layout_changed<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            new_bounds: *const _cef_rect_t,
+        ) {
+            let (arg_self_, arg_view, arg_new_bounds) = (self_, view, new_bounds);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_new_bounds = if arg_new_bounds.is_null() {
+                None
+            } else {
+                Some(WrapParamRef::<Rect, _>::from(arg_new_bounds))
+            };
+            let arg_new_bounds = arg_new_bounds.as_ref().map(|arg| arg.as_ref());
+            ImplViewDelegate::on_layout_changed(&arg_self_.interface, arg_view, arg_new_bounds)
+        }
+        extern "C" fn on_focus<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_focus(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_blur<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_blur(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_theme_changed<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_theme_changed(&arg_self_.interface, arg_view)
+        }
     }
 }
 impl ImplViewDelegate for TextfieldDelegate {
@@ -38059,7 +38607,7 @@ pub trait ImplBrowserViewDelegate: ImplViewDelegate {
         Default::default()
     }
     fn init_methods(object: &mut _cef_browser_view_delegate_t) {
-        impl_cef_view_delegate_t::init_methods::<Self>(&mut object.base);
+        impl_cef_browser_view_delegate_t::bridge_cef_view_delegate_t::init_methods::<Self>(object);
         impl_cef_browser_view_delegate_t::init_methods::<Self>(object);
     }
     fn get_raw(&self) -> *mut _cef_browser_view_delegate_t {
@@ -38244,6 +38792,179 @@ mod impl_cef_browser_view_delegate_t {
             &arg_self_.interface,
             arg_browser_view,
         )
+    }
+    pub(crate) mod bridge_cef_view_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplBrowserViewDelegate>(object: &mut _cef_browser_view_delegate_t) {
+            object.base.get_preferred_size = Some(get_preferred_size::<I>);
+            object.base.get_minimum_size = Some(get_minimum_size::<I>);
+            object.base.get_maximum_size = Some(get_maximum_size::<I>);
+            object.base.get_height_for_width = Some(get_height_for_width::<I>);
+            object.base.on_parent_view_changed = Some(on_parent_view_changed::<I>);
+            object.base.on_child_view_changed = Some(on_child_view_changed::<I>);
+            object.base.on_window_changed = Some(on_window_changed::<I>);
+            object.base.on_layout_changed = Some(on_layout_changed::<I>);
+            object.base.on_focus = Some(on_focus::<I>);
+            object.base.on_blur = Some(on_blur::<I>);
+            object.base.on_theme_changed = Some(on_theme_changed::<I>);
+        }
+        extern "C" fn get_preferred_size<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::preferred_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_minimum_size<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::minimum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_maximum_size<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::maximum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_height_for_width<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            width: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int {
+            let (arg_self_, arg_view, arg_width) = (self_, view, width);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_width = arg_width.into_raw();
+            ImplViewDelegate::height_for_width(&arg_self_.interface, arg_view, arg_width)
+        }
+        extern "C" fn on_parent_view_changed<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            parent: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_parent) = (self_, view, added, parent);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_parent =
+                unsafe { arg_parent.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_parent = arg_parent.as_mut();
+            ImplViewDelegate::on_parent_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_parent,
+            )
+        }
+        extern "C" fn on_child_view_changed<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            child: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_child) = (self_, view, added, child);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_child =
+                unsafe { arg_child.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_child = arg_child.as_mut();
+            ImplViewDelegate::on_child_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_child,
+            )
+        }
+        extern "C" fn on_window_changed<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+        ) {
+            let (arg_self_, arg_view, arg_added) = (self_, view, added);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            ImplViewDelegate::on_window_changed(&arg_self_.interface, arg_view, arg_added)
+        }
+        extern "C" fn on_layout_changed<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            new_bounds: *const _cef_rect_t,
+        ) {
+            let (arg_self_, arg_view, arg_new_bounds) = (self_, view, new_bounds);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_new_bounds = if arg_new_bounds.is_null() {
+                None
+            } else {
+                Some(WrapParamRef::<Rect, _>::from(arg_new_bounds))
+            };
+            let arg_new_bounds = arg_new_bounds.as_ref().map(|arg| arg.as_ref());
+            ImplViewDelegate::on_layout_changed(&arg_self_.interface, arg_view, arg_new_bounds)
+        }
+        extern "C" fn on_focus<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_focus(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_blur<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_blur(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_theme_changed<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_theme_changed(&arg_self_.interface, arg_view)
+        }
     }
 }
 impl ImplViewDelegate for BrowserViewDelegate {
@@ -39676,7 +40397,7 @@ pub trait WrapPanelDelegate: ImplPanelDelegate {
 }
 pub trait ImplPanelDelegate: ImplViewDelegate {
     fn init_methods(object: &mut _cef_panel_delegate_t) {
-        impl_cef_view_delegate_t::init_methods::<Self>(&mut object.base);
+        impl_cef_panel_delegate_t::bridge_cef_view_delegate_t::init_methods::<Self>(object);
         impl_cef_panel_delegate_t::init_methods::<Self>(object);
     }
     fn get_raw(&self) -> *mut _cef_panel_delegate_t {
@@ -39689,6 +40410,179 @@ macro_rules ! wrap_panel_delegate { ($ vis : vis struct $ name : ident ; impl Vi
 mod impl_cef_panel_delegate_t {
     use super::*;
     pub fn init_methods<I: ImplPanelDelegate>(object: &mut _cef_panel_delegate_t) {}
+    pub(crate) mod bridge_cef_view_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplPanelDelegate>(object: &mut _cef_panel_delegate_t) {
+            object.base.get_preferred_size = Some(get_preferred_size::<I>);
+            object.base.get_minimum_size = Some(get_minimum_size::<I>);
+            object.base.get_maximum_size = Some(get_maximum_size::<I>);
+            object.base.get_height_for_width = Some(get_height_for_width::<I>);
+            object.base.on_parent_view_changed = Some(on_parent_view_changed::<I>);
+            object.base.on_child_view_changed = Some(on_child_view_changed::<I>);
+            object.base.on_window_changed = Some(on_window_changed::<I>);
+            object.base.on_layout_changed = Some(on_layout_changed::<I>);
+            object.base.on_focus = Some(on_focus::<I>);
+            object.base.on_blur = Some(on_blur::<I>);
+            object.base.on_theme_changed = Some(on_theme_changed::<I>);
+        }
+        extern "C" fn get_preferred_size<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::preferred_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_minimum_size<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::minimum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_maximum_size<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::maximum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_height_for_width<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            width: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int {
+            let (arg_self_, arg_view, arg_width) = (self_, view, width);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_width = arg_width.into_raw();
+            ImplViewDelegate::height_for_width(&arg_self_.interface, arg_view, arg_width)
+        }
+        extern "C" fn on_parent_view_changed<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            parent: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_parent) = (self_, view, added, parent);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_parent =
+                unsafe { arg_parent.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_parent = arg_parent.as_mut();
+            ImplViewDelegate::on_parent_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_parent,
+            )
+        }
+        extern "C" fn on_child_view_changed<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            child: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_child) = (self_, view, added, child);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_child =
+                unsafe { arg_child.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_child = arg_child.as_mut();
+            ImplViewDelegate::on_child_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_child,
+            )
+        }
+        extern "C" fn on_window_changed<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+        ) {
+            let (arg_self_, arg_view, arg_added) = (self_, view, added);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            ImplViewDelegate::on_window_changed(&arg_self_.interface, arg_view, arg_added)
+        }
+        extern "C" fn on_layout_changed<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            new_bounds: *const _cef_rect_t,
+        ) {
+            let (arg_self_, arg_view, arg_new_bounds) = (self_, view, new_bounds);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_new_bounds = if arg_new_bounds.is_null() {
+                None
+            } else {
+                Some(WrapParamRef::<Rect, _>::from(arg_new_bounds))
+            };
+            let arg_new_bounds = arg_new_bounds.as_ref().map(|arg| arg.as_ref());
+            ImplViewDelegate::on_layout_changed(&arg_self_.interface, arg_view, arg_new_bounds)
+        }
+        extern "C" fn on_focus<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_focus(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_blur<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_blur(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_theme_changed<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_theme_changed(&arg_self_.interface, arg_view)
+        }
+    }
 }
 impl ImplViewDelegate for PanelDelegate {
     fn preferred_size(&self, view: Option<&mut View>) -> Size {
@@ -40347,8 +41241,8 @@ pub trait ImplWindowDelegate: ImplPanelDelegate {
         Default::default()
     }
     fn init_methods(object: &mut _cef_window_delegate_t) {
-        impl_cef_view_delegate_t::init_methods::<Self>(&mut object.base.base);
-        impl_cef_panel_delegate_t::init_methods::<Self>(&mut object.base);
+        impl_cef_window_delegate_t::bridge_cef_view_delegate_t::init_methods::<Self>(object);
+        impl_cef_window_delegate_t::bridge_cef_panel_delegate_t::init_methods::<Self>(object);
         impl_cef_window_delegate_t::init_methods::<Self>(object);
     }
     fn get_raw(&self) -> *mut _cef_window_delegate_t {
@@ -40720,6 +41614,183 @@ mod impl_cef_window_delegate_t {
             arg_window,
             arg_properties,
         )
+    }
+    pub(crate) mod bridge_cef_view_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplWindowDelegate>(object: &mut _cef_window_delegate_t) {
+            object.base.base.get_preferred_size = Some(get_preferred_size::<I>);
+            object.base.base.get_minimum_size = Some(get_minimum_size::<I>);
+            object.base.base.get_maximum_size = Some(get_maximum_size::<I>);
+            object.base.base.get_height_for_width = Some(get_height_for_width::<I>);
+            object.base.base.on_parent_view_changed = Some(on_parent_view_changed::<I>);
+            object.base.base.on_child_view_changed = Some(on_child_view_changed::<I>);
+            object.base.base.on_window_changed = Some(on_window_changed::<I>);
+            object.base.base.on_layout_changed = Some(on_layout_changed::<I>);
+            object.base.base.on_focus = Some(on_focus::<I>);
+            object.base.base.on_blur = Some(on_blur::<I>);
+            object.base.base.on_theme_changed = Some(on_theme_changed::<I>);
+        }
+        extern "C" fn get_preferred_size<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::preferred_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_minimum_size<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::minimum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_maximum_size<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::maximum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_height_for_width<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            width: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int {
+            let (arg_self_, arg_view, arg_width) = (self_, view, width);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_width = arg_width.into_raw();
+            ImplViewDelegate::height_for_width(&arg_self_.interface, arg_view, arg_width)
+        }
+        extern "C" fn on_parent_view_changed<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            parent: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_parent) = (self_, view, added, parent);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_parent =
+                unsafe { arg_parent.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_parent = arg_parent.as_mut();
+            ImplViewDelegate::on_parent_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_parent,
+            )
+        }
+        extern "C" fn on_child_view_changed<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            child: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_child) = (self_, view, added, child);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_child =
+                unsafe { arg_child.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_child = arg_child.as_mut();
+            ImplViewDelegate::on_child_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_child,
+            )
+        }
+        extern "C" fn on_window_changed<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+        ) {
+            let (arg_self_, arg_view, arg_added) = (self_, view, added);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            ImplViewDelegate::on_window_changed(&arg_self_.interface, arg_view, arg_added)
+        }
+        extern "C" fn on_layout_changed<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            new_bounds: *const _cef_rect_t,
+        ) {
+            let (arg_self_, arg_view, arg_new_bounds) = (self_, view, new_bounds);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_new_bounds = if arg_new_bounds.is_null() {
+                None
+            } else {
+                Some(WrapParamRef::<Rect, _>::from(arg_new_bounds))
+            };
+            let arg_new_bounds = arg_new_bounds.as_ref().map(|arg| arg.as_ref());
+            ImplViewDelegate::on_layout_changed(&arg_self_.interface, arg_view, arg_new_bounds)
+        }
+        extern "C" fn on_focus<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_focus(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_blur<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_blur(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_theme_changed<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_theme_changed(&arg_self_.interface, arg_view)
+        }
+    }
+    pub(crate) mod bridge_cef_panel_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplWindowDelegate>(object: &mut _cef_window_delegate_t) {}
     }
 }
 impl ImplViewDelegate for WindowDelegate {

--- a/cef/src/bindings/aarch64_unknown_linux_gnu.rs
+++ b/cef/src/bindings/aarch64_unknown_linux_gnu.rs
@@ -35957,7 +35957,7 @@ pub trait ImplButtonDelegate: ImplViewDelegate {
     #[doc = "See [`_cef_button_delegate_t::on_button_state_changed`] for more documentation."]
     fn on_button_state_changed(&self, button: Option<&mut Button>) {}
     fn init_methods(object: &mut _cef_button_delegate_t) {
-        impl_cef_view_delegate_t::init_methods::<Self>(&mut object.base);
+        impl_cef_button_delegate_t::bridge_cef_view_delegate_t::init_methods::<Self>(object);
         impl_cef_button_delegate_t::init_methods::<Self>(object);
     }
     fn get_raw(&self) -> *mut _cef_button_delegate_t {
@@ -35994,6 +35994,179 @@ mod impl_cef_button_delegate_t {
             unsafe { arg_button.as_mut() }.map(|arg| Button(unsafe { RefGuard::from_raw(arg) }));
         let arg_button = arg_button.as_mut();
         ImplButtonDelegate::on_button_state_changed(&arg_self_.interface, arg_button)
+    }
+    pub(crate) mod bridge_cef_view_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplButtonDelegate>(object: &mut _cef_button_delegate_t) {
+            object.base.get_preferred_size = Some(get_preferred_size::<I>);
+            object.base.get_minimum_size = Some(get_minimum_size::<I>);
+            object.base.get_maximum_size = Some(get_maximum_size::<I>);
+            object.base.get_height_for_width = Some(get_height_for_width::<I>);
+            object.base.on_parent_view_changed = Some(on_parent_view_changed::<I>);
+            object.base.on_child_view_changed = Some(on_child_view_changed::<I>);
+            object.base.on_window_changed = Some(on_window_changed::<I>);
+            object.base.on_layout_changed = Some(on_layout_changed::<I>);
+            object.base.on_focus = Some(on_focus::<I>);
+            object.base.on_blur = Some(on_blur::<I>);
+            object.base.on_theme_changed = Some(on_theme_changed::<I>);
+        }
+        extern "C" fn get_preferred_size<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::preferred_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_minimum_size<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::minimum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_maximum_size<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::maximum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_height_for_width<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            width: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int {
+            let (arg_self_, arg_view, arg_width) = (self_, view, width);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_width = arg_width.into_raw();
+            ImplViewDelegate::height_for_width(&arg_self_.interface, arg_view, arg_width)
+        }
+        extern "C" fn on_parent_view_changed<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            parent: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_parent) = (self_, view, added, parent);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_parent =
+                unsafe { arg_parent.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_parent = arg_parent.as_mut();
+            ImplViewDelegate::on_parent_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_parent,
+            )
+        }
+        extern "C" fn on_child_view_changed<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            child: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_child) = (self_, view, added, child);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_child =
+                unsafe { arg_child.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_child = arg_child.as_mut();
+            ImplViewDelegate::on_child_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_child,
+            )
+        }
+        extern "C" fn on_window_changed<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+        ) {
+            let (arg_self_, arg_view, arg_added) = (self_, view, added);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            ImplViewDelegate::on_window_changed(&arg_self_.interface, arg_view, arg_added)
+        }
+        extern "C" fn on_layout_changed<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            new_bounds: *const _cef_rect_t,
+        ) {
+            let (arg_self_, arg_view, arg_new_bounds) = (self_, view, new_bounds);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_new_bounds = if arg_new_bounds.is_null() {
+                None
+            } else {
+                Some(WrapParamRef::<Rect, _>::from(arg_new_bounds))
+            };
+            let arg_new_bounds = arg_new_bounds.as_ref().map(|arg| arg.as_ref());
+            ImplViewDelegate::on_layout_changed(&arg_self_.interface, arg_view, arg_new_bounds)
+        }
+        extern "C" fn on_focus<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_focus(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_blur<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_blur(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_theme_changed<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_theme_changed(&arg_self_.interface, arg_view)
+        }
     }
 }
 impl ImplViewDelegate for ButtonDelegate {
@@ -36615,8 +36788,8 @@ pub trait ImplMenuButtonDelegate: ImplButtonDelegate {
     ) {
     }
     fn init_methods(object: &mut _cef_menu_button_delegate_t) {
-        impl_cef_view_delegate_t::init_methods::<Self>(&mut object.base.base);
-        impl_cef_button_delegate_t::init_methods::<Self>(&mut object.base);
+        impl_cef_menu_button_delegate_t::bridge_cef_view_delegate_t::init_methods::<Self>(object);
+        impl_cef_menu_button_delegate_t::bridge_cef_button_delegate_t::init_methods::<Self>(object);
         impl_cef_menu_button_delegate_t::init_methods::<Self>(object);
     }
     fn get_raw(&self) -> *mut _cef_menu_button_delegate_t {
@@ -36658,6 +36831,208 @@ mod impl_cef_menu_button_delegate_t {
             arg_screen_point,
             arg_button_pressed_lock,
         )
+    }
+    pub(crate) mod bridge_cef_view_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplMenuButtonDelegate>(object: &mut _cef_menu_button_delegate_t) {
+            object.base.base.get_preferred_size = Some(get_preferred_size::<I>);
+            object.base.base.get_minimum_size = Some(get_minimum_size::<I>);
+            object.base.base.get_maximum_size = Some(get_maximum_size::<I>);
+            object.base.base.get_height_for_width = Some(get_height_for_width::<I>);
+            object.base.base.on_parent_view_changed = Some(on_parent_view_changed::<I>);
+            object.base.base.on_child_view_changed = Some(on_child_view_changed::<I>);
+            object.base.base.on_window_changed = Some(on_window_changed::<I>);
+            object.base.base.on_layout_changed = Some(on_layout_changed::<I>);
+            object.base.base.on_focus = Some(on_focus::<I>);
+            object.base.base.on_blur = Some(on_blur::<I>);
+            object.base.base.on_theme_changed = Some(on_theme_changed::<I>);
+        }
+        extern "C" fn get_preferred_size<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::preferred_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_minimum_size<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::minimum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_maximum_size<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::maximum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_height_for_width<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            width: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int {
+            let (arg_self_, arg_view, arg_width) = (self_, view, width);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_width = arg_width.into_raw();
+            ImplViewDelegate::height_for_width(&arg_self_.interface, arg_view, arg_width)
+        }
+        extern "C" fn on_parent_view_changed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            parent: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_parent) = (self_, view, added, parent);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_parent =
+                unsafe { arg_parent.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_parent = arg_parent.as_mut();
+            ImplViewDelegate::on_parent_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_parent,
+            )
+        }
+        extern "C" fn on_child_view_changed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            child: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_child) = (self_, view, added, child);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_child =
+                unsafe { arg_child.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_child = arg_child.as_mut();
+            ImplViewDelegate::on_child_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_child,
+            )
+        }
+        extern "C" fn on_window_changed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+        ) {
+            let (arg_self_, arg_view, arg_added) = (self_, view, added);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            ImplViewDelegate::on_window_changed(&arg_self_.interface, arg_view, arg_added)
+        }
+        extern "C" fn on_layout_changed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            new_bounds: *const _cef_rect_t,
+        ) {
+            let (arg_self_, arg_view, arg_new_bounds) = (self_, view, new_bounds);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_new_bounds = if arg_new_bounds.is_null() {
+                None
+            } else {
+                Some(WrapParamRef::<Rect, _>::from(arg_new_bounds))
+            };
+            let arg_new_bounds = arg_new_bounds.as_ref().map(|arg| arg.as_ref());
+            ImplViewDelegate::on_layout_changed(&arg_self_.interface, arg_view, arg_new_bounds)
+        }
+        extern "C" fn on_focus<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_focus(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_blur<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_blur(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_theme_changed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_theme_changed(&arg_self_.interface, arg_view)
+        }
+    }
+    pub(crate) mod bridge_cef_button_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplMenuButtonDelegate>(object: &mut _cef_menu_button_delegate_t) {
+            object.base.on_button_pressed = Some(on_button_pressed::<I>);
+            object.base.on_button_state_changed = Some(on_button_state_changed::<I>);
+        }
+        extern "C" fn on_button_pressed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_button_delegate_t,
+            button: *mut _cef_button_t,
+        ) {
+            let (arg_self_, arg_button) = (self_, button);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_button = unsafe { arg_button.as_mut() }
+                .map(|arg| Button(unsafe { RefGuard::from_raw(arg) }));
+            let arg_button = arg_button.as_mut();
+            ImplButtonDelegate::on_button_pressed(&arg_self_.interface, arg_button)
+        }
+        extern "C" fn on_button_state_changed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_button_delegate_t,
+            button: *mut _cef_button_t,
+        ) {
+            let (arg_self_, arg_button) = (self_, button);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_button = unsafe { arg_button.as_mut() }
+                .map(|arg| Button(unsafe { RefGuard::from_raw(arg) }));
+            let arg_button = arg_button.as_mut();
+            ImplButtonDelegate::on_button_state_changed(&arg_self_.interface, arg_button)
+        }
     }
 }
 impl ImplViewDelegate for MenuButtonDelegate {
@@ -37184,7 +37559,7 @@ pub trait ImplTextfieldDelegate: ImplViewDelegate {
     #[doc = "See [`_cef_textfield_delegate_t::on_after_user_action`] for more documentation."]
     fn on_after_user_action(&self, textfield: Option<&mut Textfield>) {}
     fn init_methods(object: &mut _cef_textfield_delegate_t) {
-        impl_cef_view_delegate_t::init_methods::<Self>(&mut object.base);
+        impl_cef_textfield_delegate_t::bridge_cef_view_delegate_t::init_methods::<Self>(object);
         impl_cef_textfield_delegate_t::init_methods::<Self>(object);
     }
     fn get_raw(&self) -> *mut _cef_textfield_delegate_t {
@@ -37228,6 +37603,179 @@ mod impl_cef_textfield_delegate_t {
             .map(|arg| Textfield(unsafe { RefGuard::from_raw(arg) }));
         let arg_textfield = arg_textfield.as_mut();
         ImplTextfieldDelegate::on_after_user_action(&arg_self_.interface, arg_textfield)
+    }
+    pub(crate) mod bridge_cef_view_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplTextfieldDelegate>(object: &mut _cef_textfield_delegate_t) {
+            object.base.get_preferred_size = Some(get_preferred_size::<I>);
+            object.base.get_minimum_size = Some(get_minimum_size::<I>);
+            object.base.get_maximum_size = Some(get_maximum_size::<I>);
+            object.base.get_height_for_width = Some(get_height_for_width::<I>);
+            object.base.on_parent_view_changed = Some(on_parent_view_changed::<I>);
+            object.base.on_child_view_changed = Some(on_child_view_changed::<I>);
+            object.base.on_window_changed = Some(on_window_changed::<I>);
+            object.base.on_layout_changed = Some(on_layout_changed::<I>);
+            object.base.on_focus = Some(on_focus::<I>);
+            object.base.on_blur = Some(on_blur::<I>);
+            object.base.on_theme_changed = Some(on_theme_changed::<I>);
+        }
+        extern "C" fn get_preferred_size<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::preferred_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_minimum_size<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::minimum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_maximum_size<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::maximum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_height_for_width<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            width: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int {
+            let (arg_self_, arg_view, arg_width) = (self_, view, width);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_width = arg_width.into_raw();
+            ImplViewDelegate::height_for_width(&arg_self_.interface, arg_view, arg_width)
+        }
+        extern "C" fn on_parent_view_changed<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            parent: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_parent) = (self_, view, added, parent);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_parent =
+                unsafe { arg_parent.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_parent = arg_parent.as_mut();
+            ImplViewDelegate::on_parent_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_parent,
+            )
+        }
+        extern "C" fn on_child_view_changed<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            child: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_child) = (self_, view, added, child);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_child =
+                unsafe { arg_child.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_child = arg_child.as_mut();
+            ImplViewDelegate::on_child_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_child,
+            )
+        }
+        extern "C" fn on_window_changed<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+        ) {
+            let (arg_self_, arg_view, arg_added) = (self_, view, added);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            ImplViewDelegate::on_window_changed(&arg_self_.interface, arg_view, arg_added)
+        }
+        extern "C" fn on_layout_changed<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            new_bounds: *const _cef_rect_t,
+        ) {
+            let (arg_self_, arg_view, arg_new_bounds) = (self_, view, new_bounds);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_new_bounds = if arg_new_bounds.is_null() {
+                None
+            } else {
+                Some(WrapParamRef::<Rect, _>::from(arg_new_bounds))
+            };
+            let arg_new_bounds = arg_new_bounds.as_ref().map(|arg| arg.as_ref());
+            ImplViewDelegate::on_layout_changed(&arg_self_.interface, arg_view, arg_new_bounds)
+        }
+        extern "C" fn on_focus<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_focus(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_blur<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_blur(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_theme_changed<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_theme_changed(&arg_self_.interface, arg_view)
+        }
     }
 }
 impl ImplViewDelegate for TextfieldDelegate {
@@ -38097,7 +38645,7 @@ pub trait ImplBrowserViewDelegate: ImplViewDelegate {
         Default::default()
     }
     fn init_methods(object: &mut _cef_browser_view_delegate_t) {
-        impl_cef_view_delegate_t::init_methods::<Self>(&mut object.base);
+        impl_cef_browser_view_delegate_t::bridge_cef_view_delegate_t::init_methods::<Self>(object);
         impl_cef_browser_view_delegate_t::init_methods::<Self>(object);
     }
     fn get_raw(&self) -> *mut _cef_browser_view_delegate_t {
@@ -38282,6 +38830,179 @@ mod impl_cef_browser_view_delegate_t {
             &arg_self_.interface,
             arg_browser_view,
         )
+    }
+    pub(crate) mod bridge_cef_view_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplBrowserViewDelegate>(object: &mut _cef_browser_view_delegate_t) {
+            object.base.get_preferred_size = Some(get_preferred_size::<I>);
+            object.base.get_minimum_size = Some(get_minimum_size::<I>);
+            object.base.get_maximum_size = Some(get_maximum_size::<I>);
+            object.base.get_height_for_width = Some(get_height_for_width::<I>);
+            object.base.on_parent_view_changed = Some(on_parent_view_changed::<I>);
+            object.base.on_child_view_changed = Some(on_child_view_changed::<I>);
+            object.base.on_window_changed = Some(on_window_changed::<I>);
+            object.base.on_layout_changed = Some(on_layout_changed::<I>);
+            object.base.on_focus = Some(on_focus::<I>);
+            object.base.on_blur = Some(on_blur::<I>);
+            object.base.on_theme_changed = Some(on_theme_changed::<I>);
+        }
+        extern "C" fn get_preferred_size<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::preferred_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_minimum_size<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::minimum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_maximum_size<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::maximum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_height_for_width<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            width: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int {
+            let (arg_self_, arg_view, arg_width) = (self_, view, width);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_width = arg_width.into_raw();
+            ImplViewDelegate::height_for_width(&arg_self_.interface, arg_view, arg_width)
+        }
+        extern "C" fn on_parent_view_changed<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            parent: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_parent) = (self_, view, added, parent);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_parent =
+                unsafe { arg_parent.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_parent = arg_parent.as_mut();
+            ImplViewDelegate::on_parent_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_parent,
+            )
+        }
+        extern "C" fn on_child_view_changed<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            child: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_child) = (self_, view, added, child);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_child =
+                unsafe { arg_child.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_child = arg_child.as_mut();
+            ImplViewDelegate::on_child_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_child,
+            )
+        }
+        extern "C" fn on_window_changed<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+        ) {
+            let (arg_self_, arg_view, arg_added) = (self_, view, added);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            ImplViewDelegate::on_window_changed(&arg_self_.interface, arg_view, arg_added)
+        }
+        extern "C" fn on_layout_changed<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            new_bounds: *const _cef_rect_t,
+        ) {
+            let (arg_self_, arg_view, arg_new_bounds) = (self_, view, new_bounds);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_new_bounds = if arg_new_bounds.is_null() {
+                None
+            } else {
+                Some(WrapParamRef::<Rect, _>::from(arg_new_bounds))
+            };
+            let arg_new_bounds = arg_new_bounds.as_ref().map(|arg| arg.as_ref());
+            ImplViewDelegate::on_layout_changed(&arg_self_.interface, arg_view, arg_new_bounds)
+        }
+        extern "C" fn on_focus<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_focus(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_blur<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_blur(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_theme_changed<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_theme_changed(&arg_self_.interface, arg_view)
+        }
     }
 }
 impl ImplViewDelegate for BrowserViewDelegate {
@@ -39714,7 +40435,7 @@ pub trait WrapPanelDelegate: ImplPanelDelegate {
 }
 pub trait ImplPanelDelegate: ImplViewDelegate {
     fn init_methods(object: &mut _cef_panel_delegate_t) {
-        impl_cef_view_delegate_t::init_methods::<Self>(&mut object.base);
+        impl_cef_panel_delegate_t::bridge_cef_view_delegate_t::init_methods::<Self>(object);
         impl_cef_panel_delegate_t::init_methods::<Self>(object);
     }
     fn get_raw(&self) -> *mut _cef_panel_delegate_t {
@@ -39727,6 +40448,179 @@ macro_rules ! wrap_panel_delegate { ($ vis : vis struct $ name : ident ; impl Vi
 mod impl_cef_panel_delegate_t {
     use super::*;
     pub fn init_methods<I: ImplPanelDelegate>(object: &mut _cef_panel_delegate_t) {}
+    pub(crate) mod bridge_cef_view_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplPanelDelegate>(object: &mut _cef_panel_delegate_t) {
+            object.base.get_preferred_size = Some(get_preferred_size::<I>);
+            object.base.get_minimum_size = Some(get_minimum_size::<I>);
+            object.base.get_maximum_size = Some(get_maximum_size::<I>);
+            object.base.get_height_for_width = Some(get_height_for_width::<I>);
+            object.base.on_parent_view_changed = Some(on_parent_view_changed::<I>);
+            object.base.on_child_view_changed = Some(on_child_view_changed::<I>);
+            object.base.on_window_changed = Some(on_window_changed::<I>);
+            object.base.on_layout_changed = Some(on_layout_changed::<I>);
+            object.base.on_focus = Some(on_focus::<I>);
+            object.base.on_blur = Some(on_blur::<I>);
+            object.base.on_theme_changed = Some(on_theme_changed::<I>);
+        }
+        extern "C" fn get_preferred_size<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::preferred_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_minimum_size<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::minimum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_maximum_size<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::maximum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_height_for_width<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            width: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int {
+            let (arg_self_, arg_view, arg_width) = (self_, view, width);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_width = arg_width.into_raw();
+            ImplViewDelegate::height_for_width(&arg_self_.interface, arg_view, arg_width)
+        }
+        extern "C" fn on_parent_view_changed<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            parent: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_parent) = (self_, view, added, parent);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_parent =
+                unsafe { arg_parent.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_parent = arg_parent.as_mut();
+            ImplViewDelegate::on_parent_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_parent,
+            )
+        }
+        extern "C" fn on_child_view_changed<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            child: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_child) = (self_, view, added, child);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_child =
+                unsafe { arg_child.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_child = arg_child.as_mut();
+            ImplViewDelegate::on_child_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_child,
+            )
+        }
+        extern "C" fn on_window_changed<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+        ) {
+            let (arg_self_, arg_view, arg_added) = (self_, view, added);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            ImplViewDelegate::on_window_changed(&arg_self_.interface, arg_view, arg_added)
+        }
+        extern "C" fn on_layout_changed<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            new_bounds: *const _cef_rect_t,
+        ) {
+            let (arg_self_, arg_view, arg_new_bounds) = (self_, view, new_bounds);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_new_bounds = if arg_new_bounds.is_null() {
+                None
+            } else {
+                Some(WrapParamRef::<Rect, _>::from(arg_new_bounds))
+            };
+            let arg_new_bounds = arg_new_bounds.as_ref().map(|arg| arg.as_ref());
+            ImplViewDelegate::on_layout_changed(&arg_self_.interface, arg_view, arg_new_bounds)
+        }
+        extern "C" fn on_focus<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_focus(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_blur<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_blur(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_theme_changed<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_theme_changed(&arg_self_.interface, arg_view)
+        }
+    }
 }
 impl ImplViewDelegate for PanelDelegate {
     fn preferred_size(&self, view: Option<&mut View>) -> Size {
@@ -40385,8 +41279,8 @@ pub trait ImplWindowDelegate: ImplPanelDelegate {
         Default::default()
     }
     fn init_methods(object: &mut _cef_window_delegate_t) {
-        impl_cef_view_delegate_t::init_methods::<Self>(&mut object.base.base);
-        impl_cef_panel_delegate_t::init_methods::<Self>(&mut object.base);
+        impl_cef_window_delegate_t::bridge_cef_view_delegate_t::init_methods::<Self>(object);
+        impl_cef_window_delegate_t::bridge_cef_panel_delegate_t::init_methods::<Self>(object);
         impl_cef_window_delegate_t::init_methods::<Self>(object);
     }
     fn get_raw(&self) -> *mut _cef_window_delegate_t {
@@ -40758,6 +41652,183 @@ mod impl_cef_window_delegate_t {
             arg_window,
             arg_properties,
         )
+    }
+    pub(crate) mod bridge_cef_view_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplWindowDelegate>(object: &mut _cef_window_delegate_t) {
+            object.base.base.get_preferred_size = Some(get_preferred_size::<I>);
+            object.base.base.get_minimum_size = Some(get_minimum_size::<I>);
+            object.base.base.get_maximum_size = Some(get_maximum_size::<I>);
+            object.base.base.get_height_for_width = Some(get_height_for_width::<I>);
+            object.base.base.on_parent_view_changed = Some(on_parent_view_changed::<I>);
+            object.base.base.on_child_view_changed = Some(on_child_view_changed::<I>);
+            object.base.base.on_window_changed = Some(on_window_changed::<I>);
+            object.base.base.on_layout_changed = Some(on_layout_changed::<I>);
+            object.base.base.on_focus = Some(on_focus::<I>);
+            object.base.base.on_blur = Some(on_blur::<I>);
+            object.base.base.on_theme_changed = Some(on_theme_changed::<I>);
+        }
+        extern "C" fn get_preferred_size<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::preferred_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_minimum_size<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::minimum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_maximum_size<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::maximum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_height_for_width<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            width: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int {
+            let (arg_self_, arg_view, arg_width) = (self_, view, width);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_width = arg_width.into_raw();
+            ImplViewDelegate::height_for_width(&arg_self_.interface, arg_view, arg_width)
+        }
+        extern "C" fn on_parent_view_changed<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            parent: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_parent) = (self_, view, added, parent);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_parent =
+                unsafe { arg_parent.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_parent = arg_parent.as_mut();
+            ImplViewDelegate::on_parent_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_parent,
+            )
+        }
+        extern "C" fn on_child_view_changed<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            child: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_child) = (self_, view, added, child);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_child =
+                unsafe { arg_child.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_child = arg_child.as_mut();
+            ImplViewDelegate::on_child_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_child,
+            )
+        }
+        extern "C" fn on_window_changed<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+        ) {
+            let (arg_self_, arg_view, arg_added) = (self_, view, added);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            ImplViewDelegate::on_window_changed(&arg_self_.interface, arg_view, arg_added)
+        }
+        extern "C" fn on_layout_changed<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            new_bounds: *const _cef_rect_t,
+        ) {
+            let (arg_self_, arg_view, arg_new_bounds) = (self_, view, new_bounds);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_new_bounds = if arg_new_bounds.is_null() {
+                None
+            } else {
+                Some(WrapParamRef::<Rect, _>::from(arg_new_bounds))
+            };
+            let arg_new_bounds = arg_new_bounds.as_ref().map(|arg| arg.as_ref());
+            ImplViewDelegate::on_layout_changed(&arg_self_.interface, arg_view, arg_new_bounds)
+        }
+        extern "C" fn on_focus<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_focus(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_blur<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_blur(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_theme_changed<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_theme_changed(&arg_self_.interface, arg_view)
+        }
+    }
+    pub(crate) mod bridge_cef_panel_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplWindowDelegate>(object: &mut _cef_window_delegate_t) {}
     }
 }
 impl ImplViewDelegate for WindowDelegate {

--- a/cef/src/bindings/arm_unknown_linux_gnueabi.rs
+++ b/cef/src/bindings/arm_unknown_linux_gnueabi.rs
@@ -35957,7 +35957,7 @@ pub trait ImplButtonDelegate: ImplViewDelegate {
     #[doc = "See [`_cef_button_delegate_t::on_button_state_changed`] for more documentation."]
     fn on_button_state_changed(&self, button: Option<&mut Button>) {}
     fn init_methods(object: &mut _cef_button_delegate_t) {
-        impl_cef_view_delegate_t::init_methods::<Self>(&mut object.base);
+        impl_cef_button_delegate_t::bridge_cef_view_delegate_t::init_methods::<Self>(object);
         impl_cef_button_delegate_t::init_methods::<Self>(object);
     }
     fn get_raw(&self) -> *mut _cef_button_delegate_t {
@@ -35994,6 +35994,179 @@ mod impl_cef_button_delegate_t {
             unsafe { arg_button.as_mut() }.map(|arg| Button(unsafe { RefGuard::from_raw(arg) }));
         let arg_button = arg_button.as_mut();
         ImplButtonDelegate::on_button_state_changed(&arg_self_.interface, arg_button)
+    }
+    pub(crate) mod bridge_cef_view_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplButtonDelegate>(object: &mut _cef_button_delegate_t) {
+            object.base.get_preferred_size = Some(get_preferred_size::<I>);
+            object.base.get_minimum_size = Some(get_minimum_size::<I>);
+            object.base.get_maximum_size = Some(get_maximum_size::<I>);
+            object.base.get_height_for_width = Some(get_height_for_width::<I>);
+            object.base.on_parent_view_changed = Some(on_parent_view_changed::<I>);
+            object.base.on_child_view_changed = Some(on_child_view_changed::<I>);
+            object.base.on_window_changed = Some(on_window_changed::<I>);
+            object.base.on_layout_changed = Some(on_layout_changed::<I>);
+            object.base.on_focus = Some(on_focus::<I>);
+            object.base.on_blur = Some(on_blur::<I>);
+            object.base.on_theme_changed = Some(on_theme_changed::<I>);
+        }
+        extern "C" fn get_preferred_size<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::preferred_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_minimum_size<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::minimum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_maximum_size<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::maximum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_height_for_width<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            width: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int {
+            let (arg_self_, arg_view, arg_width) = (self_, view, width);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_width = arg_width.into_raw();
+            ImplViewDelegate::height_for_width(&arg_self_.interface, arg_view, arg_width)
+        }
+        extern "C" fn on_parent_view_changed<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            parent: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_parent) = (self_, view, added, parent);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_parent =
+                unsafe { arg_parent.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_parent = arg_parent.as_mut();
+            ImplViewDelegate::on_parent_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_parent,
+            )
+        }
+        extern "C" fn on_child_view_changed<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            child: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_child) = (self_, view, added, child);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_child =
+                unsafe { arg_child.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_child = arg_child.as_mut();
+            ImplViewDelegate::on_child_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_child,
+            )
+        }
+        extern "C" fn on_window_changed<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+        ) {
+            let (arg_self_, arg_view, arg_added) = (self_, view, added);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            ImplViewDelegate::on_window_changed(&arg_self_.interface, arg_view, arg_added)
+        }
+        extern "C" fn on_layout_changed<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            new_bounds: *const _cef_rect_t,
+        ) {
+            let (arg_self_, arg_view, arg_new_bounds) = (self_, view, new_bounds);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_new_bounds = if arg_new_bounds.is_null() {
+                None
+            } else {
+                Some(WrapParamRef::<Rect, _>::from(arg_new_bounds))
+            };
+            let arg_new_bounds = arg_new_bounds.as_ref().map(|arg| arg.as_ref());
+            ImplViewDelegate::on_layout_changed(&arg_self_.interface, arg_view, arg_new_bounds)
+        }
+        extern "C" fn on_focus<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_focus(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_blur<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_blur(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_theme_changed<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_theme_changed(&arg_self_.interface, arg_view)
+        }
     }
 }
 impl ImplViewDelegate for ButtonDelegate {
@@ -36615,8 +36788,8 @@ pub trait ImplMenuButtonDelegate: ImplButtonDelegate {
     ) {
     }
     fn init_methods(object: &mut _cef_menu_button_delegate_t) {
-        impl_cef_view_delegate_t::init_methods::<Self>(&mut object.base.base);
-        impl_cef_button_delegate_t::init_methods::<Self>(&mut object.base);
+        impl_cef_menu_button_delegate_t::bridge_cef_view_delegate_t::init_methods::<Self>(object);
+        impl_cef_menu_button_delegate_t::bridge_cef_button_delegate_t::init_methods::<Self>(object);
         impl_cef_menu_button_delegate_t::init_methods::<Self>(object);
     }
     fn get_raw(&self) -> *mut _cef_menu_button_delegate_t {
@@ -36658,6 +36831,208 @@ mod impl_cef_menu_button_delegate_t {
             arg_screen_point,
             arg_button_pressed_lock,
         )
+    }
+    pub(crate) mod bridge_cef_view_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplMenuButtonDelegate>(object: &mut _cef_menu_button_delegate_t) {
+            object.base.base.get_preferred_size = Some(get_preferred_size::<I>);
+            object.base.base.get_minimum_size = Some(get_minimum_size::<I>);
+            object.base.base.get_maximum_size = Some(get_maximum_size::<I>);
+            object.base.base.get_height_for_width = Some(get_height_for_width::<I>);
+            object.base.base.on_parent_view_changed = Some(on_parent_view_changed::<I>);
+            object.base.base.on_child_view_changed = Some(on_child_view_changed::<I>);
+            object.base.base.on_window_changed = Some(on_window_changed::<I>);
+            object.base.base.on_layout_changed = Some(on_layout_changed::<I>);
+            object.base.base.on_focus = Some(on_focus::<I>);
+            object.base.base.on_blur = Some(on_blur::<I>);
+            object.base.base.on_theme_changed = Some(on_theme_changed::<I>);
+        }
+        extern "C" fn get_preferred_size<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::preferred_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_minimum_size<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::minimum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_maximum_size<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::maximum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_height_for_width<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            width: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int {
+            let (arg_self_, arg_view, arg_width) = (self_, view, width);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_width = arg_width.into_raw();
+            ImplViewDelegate::height_for_width(&arg_self_.interface, arg_view, arg_width)
+        }
+        extern "C" fn on_parent_view_changed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            parent: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_parent) = (self_, view, added, parent);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_parent =
+                unsafe { arg_parent.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_parent = arg_parent.as_mut();
+            ImplViewDelegate::on_parent_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_parent,
+            )
+        }
+        extern "C" fn on_child_view_changed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            child: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_child) = (self_, view, added, child);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_child =
+                unsafe { arg_child.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_child = arg_child.as_mut();
+            ImplViewDelegate::on_child_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_child,
+            )
+        }
+        extern "C" fn on_window_changed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+        ) {
+            let (arg_self_, arg_view, arg_added) = (self_, view, added);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            ImplViewDelegate::on_window_changed(&arg_self_.interface, arg_view, arg_added)
+        }
+        extern "C" fn on_layout_changed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            new_bounds: *const _cef_rect_t,
+        ) {
+            let (arg_self_, arg_view, arg_new_bounds) = (self_, view, new_bounds);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_new_bounds = if arg_new_bounds.is_null() {
+                None
+            } else {
+                Some(WrapParamRef::<Rect, _>::from(arg_new_bounds))
+            };
+            let arg_new_bounds = arg_new_bounds.as_ref().map(|arg| arg.as_ref());
+            ImplViewDelegate::on_layout_changed(&arg_self_.interface, arg_view, arg_new_bounds)
+        }
+        extern "C" fn on_focus<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_focus(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_blur<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_blur(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_theme_changed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_theme_changed(&arg_self_.interface, arg_view)
+        }
+    }
+    pub(crate) mod bridge_cef_button_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplMenuButtonDelegate>(object: &mut _cef_menu_button_delegate_t) {
+            object.base.on_button_pressed = Some(on_button_pressed::<I>);
+            object.base.on_button_state_changed = Some(on_button_state_changed::<I>);
+        }
+        extern "C" fn on_button_pressed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_button_delegate_t,
+            button: *mut _cef_button_t,
+        ) {
+            let (arg_self_, arg_button) = (self_, button);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_button = unsafe { arg_button.as_mut() }
+                .map(|arg| Button(unsafe { RefGuard::from_raw(arg) }));
+            let arg_button = arg_button.as_mut();
+            ImplButtonDelegate::on_button_pressed(&arg_self_.interface, arg_button)
+        }
+        extern "C" fn on_button_state_changed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_button_delegate_t,
+            button: *mut _cef_button_t,
+        ) {
+            let (arg_self_, arg_button) = (self_, button);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_button = unsafe { arg_button.as_mut() }
+                .map(|arg| Button(unsafe { RefGuard::from_raw(arg) }));
+            let arg_button = arg_button.as_mut();
+            ImplButtonDelegate::on_button_state_changed(&arg_self_.interface, arg_button)
+        }
     }
 }
 impl ImplViewDelegate for MenuButtonDelegate {
@@ -37184,7 +37559,7 @@ pub trait ImplTextfieldDelegate: ImplViewDelegate {
     #[doc = "See [`_cef_textfield_delegate_t::on_after_user_action`] for more documentation."]
     fn on_after_user_action(&self, textfield: Option<&mut Textfield>) {}
     fn init_methods(object: &mut _cef_textfield_delegate_t) {
-        impl_cef_view_delegate_t::init_methods::<Self>(&mut object.base);
+        impl_cef_textfield_delegate_t::bridge_cef_view_delegate_t::init_methods::<Self>(object);
         impl_cef_textfield_delegate_t::init_methods::<Self>(object);
     }
     fn get_raw(&self) -> *mut _cef_textfield_delegate_t {
@@ -37228,6 +37603,179 @@ mod impl_cef_textfield_delegate_t {
             .map(|arg| Textfield(unsafe { RefGuard::from_raw(arg) }));
         let arg_textfield = arg_textfield.as_mut();
         ImplTextfieldDelegate::on_after_user_action(&arg_self_.interface, arg_textfield)
+    }
+    pub(crate) mod bridge_cef_view_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplTextfieldDelegate>(object: &mut _cef_textfield_delegate_t) {
+            object.base.get_preferred_size = Some(get_preferred_size::<I>);
+            object.base.get_minimum_size = Some(get_minimum_size::<I>);
+            object.base.get_maximum_size = Some(get_maximum_size::<I>);
+            object.base.get_height_for_width = Some(get_height_for_width::<I>);
+            object.base.on_parent_view_changed = Some(on_parent_view_changed::<I>);
+            object.base.on_child_view_changed = Some(on_child_view_changed::<I>);
+            object.base.on_window_changed = Some(on_window_changed::<I>);
+            object.base.on_layout_changed = Some(on_layout_changed::<I>);
+            object.base.on_focus = Some(on_focus::<I>);
+            object.base.on_blur = Some(on_blur::<I>);
+            object.base.on_theme_changed = Some(on_theme_changed::<I>);
+        }
+        extern "C" fn get_preferred_size<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::preferred_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_minimum_size<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::minimum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_maximum_size<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::maximum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_height_for_width<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            width: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int {
+            let (arg_self_, arg_view, arg_width) = (self_, view, width);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_width = arg_width.into_raw();
+            ImplViewDelegate::height_for_width(&arg_self_.interface, arg_view, arg_width)
+        }
+        extern "C" fn on_parent_view_changed<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            parent: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_parent) = (self_, view, added, parent);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_parent =
+                unsafe { arg_parent.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_parent = arg_parent.as_mut();
+            ImplViewDelegate::on_parent_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_parent,
+            )
+        }
+        extern "C" fn on_child_view_changed<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            child: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_child) = (self_, view, added, child);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_child =
+                unsafe { arg_child.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_child = arg_child.as_mut();
+            ImplViewDelegate::on_child_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_child,
+            )
+        }
+        extern "C" fn on_window_changed<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+        ) {
+            let (arg_self_, arg_view, arg_added) = (self_, view, added);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            ImplViewDelegate::on_window_changed(&arg_self_.interface, arg_view, arg_added)
+        }
+        extern "C" fn on_layout_changed<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            new_bounds: *const _cef_rect_t,
+        ) {
+            let (arg_self_, arg_view, arg_new_bounds) = (self_, view, new_bounds);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_new_bounds = if arg_new_bounds.is_null() {
+                None
+            } else {
+                Some(WrapParamRef::<Rect, _>::from(arg_new_bounds))
+            };
+            let arg_new_bounds = arg_new_bounds.as_ref().map(|arg| arg.as_ref());
+            ImplViewDelegate::on_layout_changed(&arg_self_.interface, arg_view, arg_new_bounds)
+        }
+        extern "C" fn on_focus<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_focus(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_blur<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_blur(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_theme_changed<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_theme_changed(&arg_self_.interface, arg_view)
+        }
     }
 }
 impl ImplViewDelegate for TextfieldDelegate {
@@ -38097,7 +38645,7 @@ pub trait ImplBrowserViewDelegate: ImplViewDelegate {
         Default::default()
     }
     fn init_methods(object: &mut _cef_browser_view_delegate_t) {
-        impl_cef_view_delegate_t::init_methods::<Self>(&mut object.base);
+        impl_cef_browser_view_delegate_t::bridge_cef_view_delegate_t::init_methods::<Self>(object);
         impl_cef_browser_view_delegate_t::init_methods::<Self>(object);
     }
     fn get_raw(&self) -> *mut _cef_browser_view_delegate_t {
@@ -38282,6 +38830,179 @@ mod impl_cef_browser_view_delegate_t {
             &arg_self_.interface,
             arg_browser_view,
         )
+    }
+    pub(crate) mod bridge_cef_view_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplBrowserViewDelegate>(object: &mut _cef_browser_view_delegate_t) {
+            object.base.get_preferred_size = Some(get_preferred_size::<I>);
+            object.base.get_minimum_size = Some(get_minimum_size::<I>);
+            object.base.get_maximum_size = Some(get_maximum_size::<I>);
+            object.base.get_height_for_width = Some(get_height_for_width::<I>);
+            object.base.on_parent_view_changed = Some(on_parent_view_changed::<I>);
+            object.base.on_child_view_changed = Some(on_child_view_changed::<I>);
+            object.base.on_window_changed = Some(on_window_changed::<I>);
+            object.base.on_layout_changed = Some(on_layout_changed::<I>);
+            object.base.on_focus = Some(on_focus::<I>);
+            object.base.on_blur = Some(on_blur::<I>);
+            object.base.on_theme_changed = Some(on_theme_changed::<I>);
+        }
+        extern "C" fn get_preferred_size<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::preferred_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_minimum_size<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::minimum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_maximum_size<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::maximum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_height_for_width<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            width: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int {
+            let (arg_self_, arg_view, arg_width) = (self_, view, width);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_width = arg_width.into_raw();
+            ImplViewDelegate::height_for_width(&arg_self_.interface, arg_view, arg_width)
+        }
+        extern "C" fn on_parent_view_changed<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            parent: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_parent) = (self_, view, added, parent);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_parent =
+                unsafe { arg_parent.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_parent = arg_parent.as_mut();
+            ImplViewDelegate::on_parent_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_parent,
+            )
+        }
+        extern "C" fn on_child_view_changed<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            child: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_child) = (self_, view, added, child);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_child =
+                unsafe { arg_child.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_child = arg_child.as_mut();
+            ImplViewDelegate::on_child_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_child,
+            )
+        }
+        extern "C" fn on_window_changed<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+        ) {
+            let (arg_self_, arg_view, arg_added) = (self_, view, added);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            ImplViewDelegate::on_window_changed(&arg_self_.interface, arg_view, arg_added)
+        }
+        extern "C" fn on_layout_changed<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            new_bounds: *const _cef_rect_t,
+        ) {
+            let (arg_self_, arg_view, arg_new_bounds) = (self_, view, new_bounds);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_new_bounds = if arg_new_bounds.is_null() {
+                None
+            } else {
+                Some(WrapParamRef::<Rect, _>::from(arg_new_bounds))
+            };
+            let arg_new_bounds = arg_new_bounds.as_ref().map(|arg| arg.as_ref());
+            ImplViewDelegate::on_layout_changed(&arg_self_.interface, arg_view, arg_new_bounds)
+        }
+        extern "C" fn on_focus<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_focus(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_blur<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_blur(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_theme_changed<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_theme_changed(&arg_self_.interface, arg_view)
+        }
     }
 }
 impl ImplViewDelegate for BrowserViewDelegate {
@@ -39714,7 +40435,7 @@ pub trait WrapPanelDelegate: ImplPanelDelegate {
 }
 pub trait ImplPanelDelegate: ImplViewDelegate {
     fn init_methods(object: &mut _cef_panel_delegate_t) {
-        impl_cef_view_delegate_t::init_methods::<Self>(&mut object.base);
+        impl_cef_panel_delegate_t::bridge_cef_view_delegate_t::init_methods::<Self>(object);
         impl_cef_panel_delegate_t::init_methods::<Self>(object);
     }
     fn get_raw(&self) -> *mut _cef_panel_delegate_t {
@@ -39727,6 +40448,179 @@ macro_rules ! wrap_panel_delegate { ($ vis : vis struct $ name : ident ; impl Vi
 mod impl_cef_panel_delegate_t {
     use super::*;
     pub fn init_methods<I: ImplPanelDelegate>(object: &mut _cef_panel_delegate_t) {}
+    pub(crate) mod bridge_cef_view_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplPanelDelegate>(object: &mut _cef_panel_delegate_t) {
+            object.base.get_preferred_size = Some(get_preferred_size::<I>);
+            object.base.get_minimum_size = Some(get_minimum_size::<I>);
+            object.base.get_maximum_size = Some(get_maximum_size::<I>);
+            object.base.get_height_for_width = Some(get_height_for_width::<I>);
+            object.base.on_parent_view_changed = Some(on_parent_view_changed::<I>);
+            object.base.on_child_view_changed = Some(on_child_view_changed::<I>);
+            object.base.on_window_changed = Some(on_window_changed::<I>);
+            object.base.on_layout_changed = Some(on_layout_changed::<I>);
+            object.base.on_focus = Some(on_focus::<I>);
+            object.base.on_blur = Some(on_blur::<I>);
+            object.base.on_theme_changed = Some(on_theme_changed::<I>);
+        }
+        extern "C" fn get_preferred_size<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::preferred_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_minimum_size<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::minimum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_maximum_size<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::maximum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_height_for_width<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            width: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int {
+            let (arg_self_, arg_view, arg_width) = (self_, view, width);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_width = arg_width.into_raw();
+            ImplViewDelegate::height_for_width(&arg_self_.interface, arg_view, arg_width)
+        }
+        extern "C" fn on_parent_view_changed<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            parent: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_parent) = (self_, view, added, parent);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_parent =
+                unsafe { arg_parent.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_parent = arg_parent.as_mut();
+            ImplViewDelegate::on_parent_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_parent,
+            )
+        }
+        extern "C" fn on_child_view_changed<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            child: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_child) = (self_, view, added, child);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_child =
+                unsafe { arg_child.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_child = arg_child.as_mut();
+            ImplViewDelegate::on_child_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_child,
+            )
+        }
+        extern "C" fn on_window_changed<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+        ) {
+            let (arg_self_, arg_view, arg_added) = (self_, view, added);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            ImplViewDelegate::on_window_changed(&arg_self_.interface, arg_view, arg_added)
+        }
+        extern "C" fn on_layout_changed<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            new_bounds: *const _cef_rect_t,
+        ) {
+            let (arg_self_, arg_view, arg_new_bounds) = (self_, view, new_bounds);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_new_bounds = if arg_new_bounds.is_null() {
+                None
+            } else {
+                Some(WrapParamRef::<Rect, _>::from(arg_new_bounds))
+            };
+            let arg_new_bounds = arg_new_bounds.as_ref().map(|arg| arg.as_ref());
+            ImplViewDelegate::on_layout_changed(&arg_self_.interface, arg_view, arg_new_bounds)
+        }
+        extern "C" fn on_focus<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_focus(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_blur<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_blur(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_theme_changed<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_theme_changed(&arg_self_.interface, arg_view)
+        }
+    }
 }
 impl ImplViewDelegate for PanelDelegate {
     fn preferred_size(&self, view: Option<&mut View>) -> Size {
@@ -40385,8 +41279,8 @@ pub trait ImplWindowDelegate: ImplPanelDelegate {
         Default::default()
     }
     fn init_methods(object: &mut _cef_window_delegate_t) {
-        impl_cef_view_delegate_t::init_methods::<Self>(&mut object.base.base);
-        impl_cef_panel_delegate_t::init_methods::<Self>(&mut object.base);
+        impl_cef_window_delegate_t::bridge_cef_view_delegate_t::init_methods::<Self>(object);
+        impl_cef_window_delegate_t::bridge_cef_panel_delegate_t::init_methods::<Self>(object);
         impl_cef_window_delegate_t::init_methods::<Self>(object);
     }
     fn get_raw(&self) -> *mut _cef_window_delegate_t {
@@ -40758,6 +41652,183 @@ mod impl_cef_window_delegate_t {
             arg_window,
             arg_properties,
         )
+    }
+    pub(crate) mod bridge_cef_view_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplWindowDelegate>(object: &mut _cef_window_delegate_t) {
+            object.base.base.get_preferred_size = Some(get_preferred_size::<I>);
+            object.base.base.get_minimum_size = Some(get_minimum_size::<I>);
+            object.base.base.get_maximum_size = Some(get_maximum_size::<I>);
+            object.base.base.get_height_for_width = Some(get_height_for_width::<I>);
+            object.base.base.on_parent_view_changed = Some(on_parent_view_changed::<I>);
+            object.base.base.on_child_view_changed = Some(on_child_view_changed::<I>);
+            object.base.base.on_window_changed = Some(on_window_changed::<I>);
+            object.base.base.on_layout_changed = Some(on_layout_changed::<I>);
+            object.base.base.on_focus = Some(on_focus::<I>);
+            object.base.base.on_blur = Some(on_blur::<I>);
+            object.base.base.on_theme_changed = Some(on_theme_changed::<I>);
+        }
+        extern "C" fn get_preferred_size<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::preferred_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_minimum_size<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::minimum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_maximum_size<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::maximum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_height_for_width<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            width: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int {
+            let (arg_self_, arg_view, arg_width) = (self_, view, width);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_width = arg_width.into_raw();
+            ImplViewDelegate::height_for_width(&arg_self_.interface, arg_view, arg_width)
+        }
+        extern "C" fn on_parent_view_changed<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            parent: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_parent) = (self_, view, added, parent);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_parent =
+                unsafe { arg_parent.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_parent = arg_parent.as_mut();
+            ImplViewDelegate::on_parent_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_parent,
+            )
+        }
+        extern "C" fn on_child_view_changed<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            child: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_child) = (self_, view, added, child);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_child =
+                unsafe { arg_child.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_child = arg_child.as_mut();
+            ImplViewDelegate::on_child_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_child,
+            )
+        }
+        extern "C" fn on_window_changed<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+        ) {
+            let (arg_self_, arg_view, arg_added) = (self_, view, added);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            ImplViewDelegate::on_window_changed(&arg_self_.interface, arg_view, arg_added)
+        }
+        extern "C" fn on_layout_changed<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            new_bounds: *const _cef_rect_t,
+        ) {
+            let (arg_self_, arg_view, arg_new_bounds) = (self_, view, new_bounds);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_new_bounds = if arg_new_bounds.is_null() {
+                None
+            } else {
+                Some(WrapParamRef::<Rect, _>::from(arg_new_bounds))
+            };
+            let arg_new_bounds = arg_new_bounds.as_ref().map(|arg| arg.as_ref());
+            ImplViewDelegate::on_layout_changed(&arg_self_.interface, arg_view, arg_new_bounds)
+        }
+        extern "C" fn on_focus<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_focus(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_blur<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_blur(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_theme_changed<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_theme_changed(&arg_self_.interface, arg_view)
+        }
+    }
+    pub(crate) mod bridge_cef_panel_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplWindowDelegate>(object: &mut _cef_window_delegate_t) {}
     }
 }
 impl ImplViewDelegate for WindowDelegate {

--- a/cef/src/bindings/x86_64_apple_darwin.rs
+++ b/cef/src/bindings/x86_64_apple_darwin.rs
@@ -35891,7 +35891,7 @@ pub trait ImplButtonDelegate: ImplViewDelegate {
     #[doc = "See [`_cef_button_delegate_t::on_button_state_changed`] for more documentation."]
     fn on_button_state_changed(&self, button: Option<&mut Button>) {}
     fn init_methods(object: &mut _cef_button_delegate_t) {
-        impl_cef_view_delegate_t::init_methods::<Self>(&mut object.base);
+        impl_cef_button_delegate_t::bridge_cef_view_delegate_t::init_methods::<Self>(object);
         impl_cef_button_delegate_t::init_methods::<Self>(object);
     }
     fn get_raw(&self) -> *mut _cef_button_delegate_t {
@@ -35928,6 +35928,179 @@ mod impl_cef_button_delegate_t {
             unsafe { arg_button.as_mut() }.map(|arg| Button(unsafe { RefGuard::from_raw(arg) }));
         let arg_button = arg_button.as_mut();
         ImplButtonDelegate::on_button_state_changed(&arg_self_.interface, arg_button)
+    }
+    pub(crate) mod bridge_cef_view_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplButtonDelegate>(object: &mut _cef_button_delegate_t) {
+            object.base.get_preferred_size = Some(get_preferred_size::<I>);
+            object.base.get_minimum_size = Some(get_minimum_size::<I>);
+            object.base.get_maximum_size = Some(get_maximum_size::<I>);
+            object.base.get_height_for_width = Some(get_height_for_width::<I>);
+            object.base.on_parent_view_changed = Some(on_parent_view_changed::<I>);
+            object.base.on_child_view_changed = Some(on_child_view_changed::<I>);
+            object.base.on_window_changed = Some(on_window_changed::<I>);
+            object.base.on_layout_changed = Some(on_layout_changed::<I>);
+            object.base.on_focus = Some(on_focus::<I>);
+            object.base.on_blur = Some(on_blur::<I>);
+            object.base.on_theme_changed = Some(on_theme_changed::<I>);
+        }
+        extern "C" fn get_preferred_size<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::preferred_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_minimum_size<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::minimum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_maximum_size<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::maximum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_height_for_width<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            width: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int {
+            let (arg_self_, arg_view, arg_width) = (self_, view, width);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_width = arg_width.into_raw();
+            ImplViewDelegate::height_for_width(&arg_self_.interface, arg_view, arg_width)
+        }
+        extern "C" fn on_parent_view_changed<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            parent: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_parent) = (self_, view, added, parent);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_parent =
+                unsafe { arg_parent.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_parent = arg_parent.as_mut();
+            ImplViewDelegate::on_parent_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_parent,
+            )
+        }
+        extern "C" fn on_child_view_changed<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            child: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_child) = (self_, view, added, child);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_child =
+                unsafe { arg_child.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_child = arg_child.as_mut();
+            ImplViewDelegate::on_child_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_child,
+            )
+        }
+        extern "C" fn on_window_changed<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+        ) {
+            let (arg_self_, arg_view, arg_added) = (self_, view, added);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            ImplViewDelegate::on_window_changed(&arg_self_.interface, arg_view, arg_added)
+        }
+        extern "C" fn on_layout_changed<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            new_bounds: *const _cef_rect_t,
+        ) {
+            let (arg_self_, arg_view, arg_new_bounds) = (self_, view, new_bounds);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_new_bounds = if arg_new_bounds.is_null() {
+                None
+            } else {
+                Some(WrapParamRef::<Rect, _>::from(arg_new_bounds))
+            };
+            let arg_new_bounds = arg_new_bounds.as_ref().map(|arg| arg.as_ref());
+            ImplViewDelegate::on_layout_changed(&arg_self_.interface, arg_view, arg_new_bounds)
+        }
+        extern "C" fn on_focus<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_focus(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_blur<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_blur(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_theme_changed<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_theme_changed(&arg_self_.interface, arg_view)
+        }
     }
 }
 impl ImplViewDelegate for ButtonDelegate {
@@ -36549,8 +36722,8 @@ pub trait ImplMenuButtonDelegate: ImplButtonDelegate {
     ) {
     }
     fn init_methods(object: &mut _cef_menu_button_delegate_t) {
-        impl_cef_view_delegate_t::init_methods::<Self>(&mut object.base.base);
-        impl_cef_button_delegate_t::init_methods::<Self>(&mut object.base);
+        impl_cef_menu_button_delegate_t::bridge_cef_view_delegate_t::init_methods::<Self>(object);
+        impl_cef_menu_button_delegate_t::bridge_cef_button_delegate_t::init_methods::<Self>(object);
         impl_cef_menu_button_delegate_t::init_methods::<Self>(object);
     }
     fn get_raw(&self) -> *mut _cef_menu_button_delegate_t {
@@ -36592,6 +36765,208 @@ mod impl_cef_menu_button_delegate_t {
             arg_screen_point,
             arg_button_pressed_lock,
         )
+    }
+    pub(crate) mod bridge_cef_view_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplMenuButtonDelegate>(object: &mut _cef_menu_button_delegate_t) {
+            object.base.base.get_preferred_size = Some(get_preferred_size::<I>);
+            object.base.base.get_minimum_size = Some(get_minimum_size::<I>);
+            object.base.base.get_maximum_size = Some(get_maximum_size::<I>);
+            object.base.base.get_height_for_width = Some(get_height_for_width::<I>);
+            object.base.base.on_parent_view_changed = Some(on_parent_view_changed::<I>);
+            object.base.base.on_child_view_changed = Some(on_child_view_changed::<I>);
+            object.base.base.on_window_changed = Some(on_window_changed::<I>);
+            object.base.base.on_layout_changed = Some(on_layout_changed::<I>);
+            object.base.base.on_focus = Some(on_focus::<I>);
+            object.base.base.on_blur = Some(on_blur::<I>);
+            object.base.base.on_theme_changed = Some(on_theme_changed::<I>);
+        }
+        extern "C" fn get_preferred_size<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::preferred_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_minimum_size<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::minimum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_maximum_size<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::maximum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_height_for_width<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            width: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int {
+            let (arg_self_, arg_view, arg_width) = (self_, view, width);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_width = arg_width.into_raw();
+            ImplViewDelegate::height_for_width(&arg_self_.interface, arg_view, arg_width)
+        }
+        extern "C" fn on_parent_view_changed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            parent: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_parent) = (self_, view, added, parent);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_parent =
+                unsafe { arg_parent.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_parent = arg_parent.as_mut();
+            ImplViewDelegate::on_parent_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_parent,
+            )
+        }
+        extern "C" fn on_child_view_changed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            child: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_child) = (self_, view, added, child);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_child =
+                unsafe { arg_child.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_child = arg_child.as_mut();
+            ImplViewDelegate::on_child_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_child,
+            )
+        }
+        extern "C" fn on_window_changed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+        ) {
+            let (arg_self_, arg_view, arg_added) = (self_, view, added);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            ImplViewDelegate::on_window_changed(&arg_self_.interface, arg_view, arg_added)
+        }
+        extern "C" fn on_layout_changed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            new_bounds: *const _cef_rect_t,
+        ) {
+            let (arg_self_, arg_view, arg_new_bounds) = (self_, view, new_bounds);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_new_bounds = if arg_new_bounds.is_null() {
+                None
+            } else {
+                Some(WrapParamRef::<Rect, _>::from(arg_new_bounds))
+            };
+            let arg_new_bounds = arg_new_bounds.as_ref().map(|arg| arg.as_ref());
+            ImplViewDelegate::on_layout_changed(&arg_self_.interface, arg_view, arg_new_bounds)
+        }
+        extern "C" fn on_focus<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_focus(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_blur<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_blur(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_theme_changed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_theme_changed(&arg_self_.interface, arg_view)
+        }
+    }
+    pub(crate) mod bridge_cef_button_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplMenuButtonDelegate>(object: &mut _cef_menu_button_delegate_t) {
+            object.base.on_button_pressed = Some(on_button_pressed::<I>);
+            object.base.on_button_state_changed = Some(on_button_state_changed::<I>);
+        }
+        extern "C" fn on_button_pressed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_button_delegate_t,
+            button: *mut _cef_button_t,
+        ) {
+            let (arg_self_, arg_button) = (self_, button);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_button = unsafe { arg_button.as_mut() }
+                .map(|arg| Button(unsafe { RefGuard::from_raw(arg) }));
+            let arg_button = arg_button.as_mut();
+            ImplButtonDelegate::on_button_pressed(&arg_self_.interface, arg_button)
+        }
+        extern "C" fn on_button_state_changed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_button_delegate_t,
+            button: *mut _cef_button_t,
+        ) {
+            let (arg_self_, arg_button) = (self_, button);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_button = unsafe { arg_button.as_mut() }
+                .map(|arg| Button(unsafe { RefGuard::from_raw(arg) }));
+            let arg_button = arg_button.as_mut();
+            ImplButtonDelegate::on_button_state_changed(&arg_self_.interface, arg_button)
+        }
     }
 }
 impl ImplViewDelegate for MenuButtonDelegate {
@@ -37118,7 +37493,7 @@ pub trait ImplTextfieldDelegate: ImplViewDelegate {
     #[doc = "See [`_cef_textfield_delegate_t::on_after_user_action`] for more documentation."]
     fn on_after_user_action(&self, textfield: Option<&mut Textfield>) {}
     fn init_methods(object: &mut _cef_textfield_delegate_t) {
-        impl_cef_view_delegate_t::init_methods::<Self>(&mut object.base);
+        impl_cef_textfield_delegate_t::bridge_cef_view_delegate_t::init_methods::<Self>(object);
         impl_cef_textfield_delegate_t::init_methods::<Self>(object);
     }
     fn get_raw(&self) -> *mut _cef_textfield_delegate_t {
@@ -37162,6 +37537,179 @@ mod impl_cef_textfield_delegate_t {
             .map(|arg| Textfield(unsafe { RefGuard::from_raw(arg) }));
         let arg_textfield = arg_textfield.as_mut();
         ImplTextfieldDelegate::on_after_user_action(&arg_self_.interface, arg_textfield)
+    }
+    pub(crate) mod bridge_cef_view_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplTextfieldDelegate>(object: &mut _cef_textfield_delegate_t) {
+            object.base.get_preferred_size = Some(get_preferred_size::<I>);
+            object.base.get_minimum_size = Some(get_minimum_size::<I>);
+            object.base.get_maximum_size = Some(get_maximum_size::<I>);
+            object.base.get_height_for_width = Some(get_height_for_width::<I>);
+            object.base.on_parent_view_changed = Some(on_parent_view_changed::<I>);
+            object.base.on_child_view_changed = Some(on_child_view_changed::<I>);
+            object.base.on_window_changed = Some(on_window_changed::<I>);
+            object.base.on_layout_changed = Some(on_layout_changed::<I>);
+            object.base.on_focus = Some(on_focus::<I>);
+            object.base.on_blur = Some(on_blur::<I>);
+            object.base.on_theme_changed = Some(on_theme_changed::<I>);
+        }
+        extern "C" fn get_preferred_size<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::preferred_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_minimum_size<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::minimum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_maximum_size<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::maximum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_height_for_width<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            width: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int {
+            let (arg_self_, arg_view, arg_width) = (self_, view, width);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_width = arg_width.into_raw();
+            ImplViewDelegate::height_for_width(&arg_self_.interface, arg_view, arg_width)
+        }
+        extern "C" fn on_parent_view_changed<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            parent: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_parent) = (self_, view, added, parent);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_parent =
+                unsafe { arg_parent.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_parent = arg_parent.as_mut();
+            ImplViewDelegate::on_parent_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_parent,
+            )
+        }
+        extern "C" fn on_child_view_changed<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            child: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_child) = (self_, view, added, child);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_child =
+                unsafe { arg_child.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_child = arg_child.as_mut();
+            ImplViewDelegate::on_child_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_child,
+            )
+        }
+        extern "C" fn on_window_changed<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+        ) {
+            let (arg_self_, arg_view, arg_added) = (self_, view, added);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            ImplViewDelegate::on_window_changed(&arg_self_.interface, arg_view, arg_added)
+        }
+        extern "C" fn on_layout_changed<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            new_bounds: *const _cef_rect_t,
+        ) {
+            let (arg_self_, arg_view, arg_new_bounds) = (self_, view, new_bounds);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_new_bounds = if arg_new_bounds.is_null() {
+                None
+            } else {
+                Some(WrapParamRef::<Rect, _>::from(arg_new_bounds))
+            };
+            let arg_new_bounds = arg_new_bounds.as_ref().map(|arg| arg.as_ref());
+            ImplViewDelegate::on_layout_changed(&arg_self_.interface, arg_view, arg_new_bounds)
+        }
+        extern "C" fn on_focus<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_focus(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_blur<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_blur(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_theme_changed<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_theme_changed(&arg_self_.interface, arg_view)
+        }
     }
 }
 impl ImplViewDelegate for TextfieldDelegate {
@@ -38031,7 +38579,7 @@ pub trait ImplBrowserViewDelegate: ImplViewDelegate {
         Default::default()
     }
     fn init_methods(object: &mut _cef_browser_view_delegate_t) {
-        impl_cef_view_delegate_t::init_methods::<Self>(&mut object.base);
+        impl_cef_browser_view_delegate_t::bridge_cef_view_delegate_t::init_methods::<Self>(object);
         impl_cef_browser_view_delegate_t::init_methods::<Self>(object);
     }
     fn get_raw(&self) -> *mut _cef_browser_view_delegate_t {
@@ -38216,6 +38764,179 @@ mod impl_cef_browser_view_delegate_t {
             &arg_self_.interface,
             arg_browser_view,
         )
+    }
+    pub(crate) mod bridge_cef_view_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplBrowserViewDelegate>(object: &mut _cef_browser_view_delegate_t) {
+            object.base.get_preferred_size = Some(get_preferred_size::<I>);
+            object.base.get_minimum_size = Some(get_minimum_size::<I>);
+            object.base.get_maximum_size = Some(get_maximum_size::<I>);
+            object.base.get_height_for_width = Some(get_height_for_width::<I>);
+            object.base.on_parent_view_changed = Some(on_parent_view_changed::<I>);
+            object.base.on_child_view_changed = Some(on_child_view_changed::<I>);
+            object.base.on_window_changed = Some(on_window_changed::<I>);
+            object.base.on_layout_changed = Some(on_layout_changed::<I>);
+            object.base.on_focus = Some(on_focus::<I>);
+            object.base.on_blur = Some(on_blur::<I>);
+            object.base.on_theme_changed = Some(on_theme_changed::<I>);
+        }
+        extern "C" fn get_preferred_size<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::preferred_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_minimum_size<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::minimum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_maximum_size<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::maximum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_height_for_width<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            width: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int {
+            let (arg_self_, arg_view, arg_width) = (self_, view, width);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_width = arg_width.into_raw();
+            ImplViewDelegate::height_for_width(&arg_self_.interface, arg_view, arg_width)
+        }
+        extern "C" fn on_parent_view_changed<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            parent: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_parent) = (self_, view, added, parent);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_parent =
+                unsafe { arg_parent.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_parent = arg_parent.as_mut();
+            ImplViewDelegate::on_parent_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_parent,
+            )
+        }
+        extern "C" fn on_child_view_changed<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            child: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_child) = (self_, view, added, child);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_child =
+                unsafe { arg_child.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_child = arg_child.as_mut();
+            ImplViewDelegate::on_child_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_child,
+            )
+        }
+        extern "C" fn on_window_changed<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+        ) {
+            let (arg_self_, arg_view, arg_added) = (self_, view, added);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            ImplViewDelegate::on_window_changed(&arg_self_.interface, arg_view, arg_added)
+        }
+        extern "C" fn on_layout_changed<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            new_bounds: *const _cef_rect_t,
+        ) {
+            let (arg_self_, arg_view, arg_new_bounds) = (self_, view, new_bounds);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_new_bounds = if arg_new_bounds.is_null() {
+                None
+            } else {
+                Some(WrapParamRef::<Rect, _>::from(arg_new_bounds))
+            };
+            let arg_new_bounds = arg_new_bounds.as_ref().map(|arg| arg.as_ref());
+            ImplViewDelegate::on_layout_changed(&arg_self_.interface, arg_view, arg_new_bounds)
+        }
+        extern "C" fn on_focus<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_focus(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_blur<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_blur(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_theme_changed<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_theme_changed(&arg_self_.interface, arg_view)
+        }
     }
 }
 impl ImplViewDelegate for BrowserViewDelegate {
@@ -39648,7 +40369,7 @@ pub trait WrapPanelDelegate: ImplPanelDelegate {
 }
 pub trait ImplPanelDelegate: ImplViewDelegate {
     fn init_methods(object: &mut _cef_panel_delegate_t) {
-        impl_cef_view_delegate_t::init_methods::<Self>(&mut object.base);
+        impl_cef_panel_delegate_t::bridge_cef_view_delegate_t::init_methods::<Self>(object);
         impl_cef_panel_delegate_t::init_methods::<Self>(object);
     }
     fn get_raw(&self) -> *mut _cef_panel_delegate_t {
@@ -39661,6 +40382,179 @@ macro_rules ! wrap_panel_delegate { ($ vis : vis struct $ name : ident ; impl Vi
 mod impl_cef_panel_delegate_t {
     use super::*;
     pub fn init_methods<I: ImplPanelDelegate>(object: &mut _cef_panel_delegate_t) {}
+    pub(crate) mod bridge_cef_view_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplPanelDelegate>(object: &mut _cef_panel_delegate_t) {
+            object.base.get_preferred_size = Some(get_preferred_size::<I>);
+            object.base.get_minimum_size = Some(get_minimum_size::<I>);
+            object.base.get_maximum_size = Some(get_maximum_size::<I>);
+            object.base.get_height_for_width = Some(get_height_for_width::<I>);
+            object.base.on_parent_view_changed = Some(on_parent_view_changed::<I>);
+            object.base.on_child_view_changed = Some(on_child_view_changed::<I>);
+            object.base.on_window_changed = Some(on_window_changed::<I>);
+            object.base.on_layout_changed = Some(on_layout_changed::<I>);
+            object.base.on_focus = Some(on_focus::<I>);
+            object.base.on_blur = Some(on_blur::<I>);
+            object.base.on_theme_changed = Some(on_theme_changed::<I>);
+        }
+        extern "C" fn get_preferred_size<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::preferred_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_minimum_size<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::minimum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_maximum_size<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::maximum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_height_for_width<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            width: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int {
+            let (arg_self_, arg_view, arg_width) = (self_, view, width);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_width = arg_width.into_raw();
+            ImplViewDelegate::height_for_width(&arg_self_.interface, arg_view, arg_width)
+        }
+        extern "C" fn on_parent_view_changed<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            parent: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_parent) = (self_, view, added, parent);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_parent =
+                unsafe { arg_parent.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_parent = arg_parent.as_mut();
+            ImplViewDelegate::on_parent_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_parent,
+            )
+        }
+        extern "C" fn on_child_view_changed<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            child: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_child) = (self_, view, added, child);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_child =
+                unsafe { arg_child.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_child = arg_child.as_mut();
+            ImplViewDelegate::on_child_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_child,
+            )
+        }
+        extern "C" fn on_window_changed<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+        ) {
+            let (arg_self_, arg_view, arg_added) = (self_, view, added);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            ImplViewDelegate::on_window_changed(&arg_self_.interface, arg_view, arg_added)
+        }
+        extern "C" fn on_layout_changed<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            new_bounds: *const _cef_rect_t,
+        ) {
+            let (arg_self_, arg_view, arg_new_bounds) = (self_, view, new_bounds);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_new_bounds = if arg_new_bounds.is_null() {
+                None
+            } else {
+                Some(WrapParamRef::<Rect, _>::from(arg_new_bounds))
+            };
+            let arg_new_bounds = arg_new_bounds.as_ref().map(|arg| arg.as_ref());
+            ImplViewDelegate::on_layout_changed(&arg_self_.interface, arg_view, arg_new_bounds)
+        }
+        extern "C" fn on_focus<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_focus(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_blur<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_blur(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_theme_changed<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_theme_changed(&arg_self_.interface, arg_view)
+        }
+    }
 }
 impl ImplViewDelegate for PanelDelegate {
     fn preferred_size(&self, view: Option<&mut View>) -> Size {
@@ -40319,8 +41213,8 @@ pub trait ImplWindowDelegate: ImplPanelDelegate {
         Default::default()
     }
     fn init_methods(object: &mut _cef_window_delegate_t) {
-        impl_cef_view_delegate_t::init_methods::<Self>(&mut object.base.base);
-        impl_cef_panel_delegate_t::init_methods::<Self>(&mut object.base);
+        impl_cef_window_delegate_t::bridge_cef_view_delegate_t::init_methods::<Self>(object);
+        impl_cef_window_delegate_t::bridge_cef_panel_delegate_t::init_methods::<Self>(object);
         impl_cef_window_delegate_t::init_methods::<Self>(object);
     }
     fn get_raw(&self) -> *mut _cef_window_delegate_t {
@@ -40692,6 +41586,183 @@ mod impl_cef_window_delegate_t {
             arg_window,
             arg_properties,
         )
+    }
+    pub(crate) mod bridge_cef_view_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplWindowDelegate>(object: &mut _cef_window_delegate_t) {
+            object.base.base.get_preferred_size = Some(get_preferred_size::<I>);
+            object.base.base.get_minimum_size = Some(get_minimum_size::<I>);
+            object.base.base.get_maximum_size = Some(get_maximum_size::<I>);
+            object.base.base.get_height_for_width = Some(get_height_for_width::<I>);
+            object.base.base.on_parent_view_changed = Some(on_parent_view_changed::<I>);
+            object.base.base.on_child_view_changed = Some(on_child_view_changed::<I>);
+            object.base.base.on_window_changed = Some(on_window_changed::<I>);
+            object.base.base.on_layout_changed = Some(on_layout_changed::<I>);
+            object.base.base.on_focus = Some(on_focus::<I>);
+            object.base.base.on_blur = Some(on_blur::<I>);
+            object.base.base.on_theme_changed = Some(on_theme_changed::<I>);
+        }
+        extern "C" fn get_preferred_size<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::preferred_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_minimum_size<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::minimum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_maximum_size<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::maximum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_height_for_width<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            width: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int {
+            let (arg_self_, arg_view, arg_width) = (self_, view, width);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_width = arg_width.into_raw();
+            ImplViewDelegate::height_for_width(&arg_self_.interface, arg_view, arg_width)
+        }
+        extern "C" fn on_parent_view_changed<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            parent: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_parent) = (self_, view, added, parent);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_parent =
+                unsafe { arg_parent.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_parent = arg_parent.as_mut();
+            ImplViewDelegate::on_parent_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_parent,
+            )
+        }
+        extern "C" fn on_child_view_changed<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            child: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_child) = (self_, view, added, child);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_child =
+                unsafe { arg_child.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_child = arg_child.as_mut();
+            ImplViewDelegate::on_child_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_child,
+            )
+        }
+        extern "C" fn on_window_changed<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+        ) {
+            let (arg_self_, arg_view, arg_added) = (self_, view, added);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            ImplViewDelegate::on_window_changed(&arg_self_.interface, arg_view, arg_added)
+        }
+        extern "C" fn on_layout_changed<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            new_bounds: *const _cef_rect_t,
+        ) {
+            let (arg_self_, arg_view, arg_new_bounds) = (self_, view, new_bounds);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_new_bounds = if arg_new_bounds.is_null() {
+                None
+            } else {
+                Some(WrapParamRef::<Rect, _>::from(arg_new_bounds))
+            };
+            let arg_new_bounds = arg_new_bounds.as_ref().map(|arg| arg.as_ref());
+            ImplViewDelegate::on_layout_changed(&arg_self_.interface, arg_view, arg_new_bounds)
+        }
+        extern "C" fn on_focus<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_focus(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_blur<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_blur(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_theme_changed<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_theme_changed(&arg_self_.interface, arg_view)
+        }
+    }
+    pub(crate) mod bridge_cef_panel_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplWindowDelegate>(object: &mut _cef_window_delegate_t) {}
     }
 }
 impl ImplViewDelegate for WindowDelegate {

--- a/cef/src/bindings/x86_64_pc_windows_msvc.rs
+++ b/cef/src/bindings/x86_64_pc_windows_msvc.rs
@@ -35919,7 +35919,7 @@ pub trait ImplButtonDelegate: ImplViewDelegate {
     #[doc = "See [`_cef_button_delegate_t::on_button_state_changed`] for more documentation."]
     fn on_button_state_changed(&self, button: Option<&mut Button>) {}
     fn init_methods(object: &mut _cef_button_delegate_t) {
-        impl_cef_view_delegate_t::init_methods::<Self>(&mut object.base);
+        impl_cef_button_delegate_t::bridge_cef_view_delegate_t::init_methods::<Self>(object);
         impl_cef_button_delegate_t::init_methods::<Self>(object);
     }
     fn get_raw(&self) -> *mut _cef_button_delegate_t {
@@ -35956,6 +35956,179 @@ mod impl_cef_button_delegate_t {
             unsafe { arg_button.as_mut() }.map(|arg| Button(unsafe { RefGuard::from_raw(arg) }));
         let arg_button = arg_button.as_mut();
         ImplButtonDelegate::on_button_state_changed(&arg_self_.interface, arg_button)
+    }
+    pub(crate) mod bridge_cef_view_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplButtonDelegate>(object: &mut _cef_button_delegate_t) {
+            object.base.get_preferred_size = Some(get_preferred_size::<I>);
+            object.base.get_minimum_size = Some(get_minimum_size::<I>);
+            object.base.get_maximum_size = Some(get_maximum_size::<I>);
+            object.base.get_height_for_width = Some(get_height_for_width::<I>);
+            object.base.on_parent_view_changed = Some(on_parent_view_changed::<I>);
+            object.base.on_child_view_changed = Some(on_child_view_changed::<I>);
+            object.base.on_window_changed = Some(on_window_changed::<I>);
+            object.base.on_layout_changed = Some(on_layout_changed::<I>);
+            object.base.on_focus = Some(on_focus::<I>);
+            object.base.on_blur = Some(on_blur::<I>);
+            object.base.on_theme_changed = Some(on_theme_changed::<I>);
+        }
+        extern "C" fn get_preferred_size<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::preferred_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_minimum_size<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::minimum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_maximum_size<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::maximum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_height_for_width<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            width: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int {
+            let (arg_self_, arg_view, arg_width) = (self_, view, width);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_width = arg_width.into_raw();
+            ImplViewDelegate::height_for_width(&arg_self_.interface, arg_view, arg_width)
+        }
+        extern "C" fn on_parent_view_changed<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            parent: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_parent) = (self_, view, added, parent);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_parent =
+                unsafe { arg_parent.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_parent = arg_parent.as_mut();
+            ImplViewDelegate::on_parent_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_parent,
+            )
+        }
+        extern "C" fn on_child_view_changed<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            child: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_child) = (self_, view, added, child);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_child =
+                unsafe { arg_child.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_child = arg_child.as_mut();
+            ImplViewDelegate::on_child_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_child,
+            )
+        }
+        extern "C" fn on_window_changed<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+        ) {
+            let (arg_self_, arg_view, arg_added) = (self_, view, added);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            ImplViewDelegate::on_window_changed(&arg_self_.interface, arg_view, arg_added)
+        }
+        extern "C" fn on_layout_changed<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            new_bounds: *const _cef_rect_t,
+        ) {
+            let (arg_self_, arg_view, arg_new_bounds) = (self_, view, new_bounds);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_new_bounds = if arg_new_bounds.is_null() {
+                None
+            } else {
+                Some(WrapParamRef::<Rect, _>::from(arg_new_bounds))
+            };
+            let arg_new_bounds = arg_new_bounds.as_ref().map(|arg| arg.as_ref());
+            ImplViewDelegate::on_layout_changed(&arg_self_.interface, arg_view, arg_new_bounds)
+        }
+        extern "C" fn on_focus<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_focus(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_blur<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_blur(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_theme_changed<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_theme_changed(&arg_self_.interface, arg_view)
+        }
     }
 }
 impl ImplViewDelegate for ButtonDelegate {
@@ -36577,8 +36750,8 @@ pub trait ImplMenuButtonDelegate: ImplButtonDelegate {
     ) {
     }
     fn init_methods(object: &mut _cef_menu_button_delegate_t) {
-        impl_cef_view_delegate_t::init_methods::<Self>(&mut object.base.base);
-        impl_cef_button_delegate_t::init_methods::<Self>(&mut object.base);
+        impl_cef_menu_button_delegate_t::bridge_cef_view_delegate_t::init_methods::<Self>(object);
+        impl_cef_menu_button_delegate_t::bridge_cef_button_delegate_t::init_methods::<Self>(object);
         impl_cef_menu_button_delegate_t::init_methods::<Self>(object);
     }
     fn get_raw(&self) -> *mut _cef_menu_button_delegate_t {
@@ -36620,6 +36793,208 @@ mod impl_cef_menu_button_delegate_t {
             arg_screen_point,
             arg_button_pressed_lock,
         )
+    }
+    pub(crate) mod bridge_cef_view_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplMenuButtonDelegate>(object: &mut _cef_menu_button_delegate_t) {
+            object.base.base.get_preferred_size = Some(get_preferred_size::<I>);
+            object.base.base.get_minimum_size = Some(get_minimum_size::<I>);
+            object.base.base.get_maximum_size = Some(get_maximum_size::<I>);
+            object.base.base.get_height_for_width = Some(get_height_for_width::<I>);
+            object.base.base.on_parent_view_changed = Some(on_parent_view_changed::<I>);
+            object.base.base.on_child_view_changed = Some(on_child_view_changed::<I>);
+            object.base.base.on_window_changed = Some(on_window_changed::<I>);
+            object.base.base.on_layout_changed = Some(on_layout_changed::<I>);
+            object.base.base.on_focus = Some(on_focus::<I>);
+            object.base.base.on_blur = Some(on_blur::<I>);
+            object.base.base.on_theme_changed = Some(on_theme_changed::<I>);
+        }
+        extern "C" fn get_preferred_size<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::preferred_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_minimum_size<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::minimum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_maximum_size<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::maximum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_height_for_width<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            width: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int {
+            let (arg_self_, arg_view, arg_width) = (self_, view, width);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_width = arg_width.into_raw();
+            ImplViewDelegate::height_for_width(&arg_self_.interface, arg_view, arg_width)
+        }
+        extern "C" fn on_parent_view_changed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            parent: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_parent) = (self_, view, added, parent);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_parent =
+                unsafe { arg_parent.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_parent = arg_parent.as_mut();
+            ImplViewDelegate::on_parent_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_parent,
+            )
+        }
+        extern "C" fn on_child_view_changed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            child: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_child) = (self_, view, added, child);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_child =
+                unsafe { arg_child.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_child = arg_child.as_mut();
+            ImplViewDelegate::on_child_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_child,
+            )
+        }
+        extern "C" fn on_window_changed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+        ) {
+            let (arg_self_, arg_view, arg_added) = (self_, view, added);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            ImplViewDelegate::on_window_changed(&arg_self_.interface, arg_view, arg_added)
+        }
+        extern "C" fn on_layout_changed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            new_bounds: *const _cef_rect_t,
+        ) {
+            let (arg_self_, arg_view, arg_new_bounds) = (self_, view, new_bounds);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_new_bounds = if arg_new_bounds.is_null() {
+                None
+            } else {
+                Some(WrapParamRef::<Rect, _>::from(arg_new_bounds))
+            };
+            let arg_new_bounds = arg_new_bounds.as_ref().map(|arg| arg.as_ref());
+            ImplViewDelegate::on_layout_changed(&arg_self_.interface, arg_view, arg_new_bounds)
+        }
+        extern "C" fn on_focus<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_focus(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_blur<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_blur(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_theme_changed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_theme_changed(&arg_self_.interface, arg_view)
+        }
+    }
+    pub(crate) mod bridge_cef_button_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplMenuButtonDelegate>(object: &mut _cef_menu_button_delegate_t) {
+            object.base.on_button_pressed = Some(on_button_pressed::<I>);
+            object.base.on_button_state_changed = Some(on_button_state_changed::<I>);
+        }
+        extern "C" fn on_button_pressed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_button_delegate_t,
+            button: *mut _cef_button_t,
+        ) {
+            let (arg_self_, arg_button) = (self_, button);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_button = unsafe { arg_button.as_mut() }
+                .map(|arg| Button(unsafe { RefGuard::from_raw(arg) }));
+            let arg_button = arg_button.as_mut();
+            ImplButtonDelegate::on_button_pressed(&arg_self_.interface, arg_button)
+        }
+        extern "C" fn on_button_state_changed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_button_delegate_t,
+            button: *mut _cef_button_t,
+        ) {
+            let (arg_self_, arg_button) = (self_, button);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_button = unsafe { arg_button.as_mut() }
+                .map(|arg| Button(unsafe { RefGuard::from_raw(arg) }));
+            let arg_button = arg_button.as_mut();
+            ImplButtonDelegate::on_button_state_changed(&arg_self_.interface, arg_button)
+        }
     }
 }
 impl ImplViewDelegate for MenuButtonDelegate {
@@ -37146,7 +37521,7 @@ pub trait ImplTextfieldDelegate: ImplViewDelegate {
     #[doc = "See [`_cef_textfield_delegate_t::on_after_user_action`] for more documentation."]
     fn on_after_user_action(&self, textfield: Option<&mut Textfield>) {}
     fn init_methods(object: &mut _cef_textfield_delegate_t) {
-        impl_cef_view_delegate_t::init_methods::<Self>(&mut object.base);
+        impl_cef_textfield_delegate_t::bridge_cef_view_delegate_t::init_methods::<Self>(object);
         impl_cef_textfield_delegate_t::init_methods::<Self>(object);
     }
     fn get_raw(&self) -> *mut _cef_textfield_delegate_t {
@@ -37190,6 +37565,179 @@ mod impl_cef_textfield_delegate_t {
             .map(|arg| Textfield(unsafe { RefGuard::from_raw(arg) }));
         let arg_textfield = arg_textfield.as_mut();
         ImplTextfieldDelegate::on_after_user_action(&arg_self_.interface, arg_textfield)
+    }
+    pub(crate) mod bridge_cef_view_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplTextfieldDelegate>(object: &mut _cef_textfield_delegate_t) {
+            object.base.get_preferred_size = Some(get_preferred_size::<I>);
+            object.base.get_minimum_size = Some(get_minimum_size::<I>);
+            object.base.get_maximum_size = Some(get_maximum_size::<I>);
+            object.base.get_height_for_width = Some(get_height_for_width::<I>);
+            object.base.on_parent_view_changed = Some(on_parent_view_changed::<I>);
+            object.base.on_child_view_changed = Some(on_child_view_changed::<I>);
+            object.base.on_window_changed = Some(on_window_changed::<I>);
+            object.base.on_layout_changed = Some(on_layout_changed::<I>);
+            object.base.on_focus = Some(on_focus::<I>);
+            object.base.on_blur = Some(on_blur::<I>);
+            object.base.on_theme_changed = Some(on_theme_changed::<I>);
+        }
+        extern "C" fn get_preferred_size<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::preferred_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_minimum_size<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::minimum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_maximum_size<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::maximum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_height_for_width<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            width: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int {
+            let (arg_self_, arg_view, arg_width) = (self_, view, width);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_width = arg_width.into_raw();
+            ImplViewDelegate::height_for_width(&arg_self_.interface, arg_view, arg_width)
+        }
+        extern "C" fn on_parent_view_changed<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            parent: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_parent) = (self_, view, added, parent);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_parent =
+                unsafe { arg_parent.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_parent = arg_parent.as_mut();
+            ImplViewDelegate::on_parent_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_parent,
+            )
+        }
+        extern "C" fn on_child_view_changed<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            child: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_child) = (self_, view, added, child);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_child =
+                unsafe { arg_child.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_child = arg_child.as_mut();
+            ImplViewDelegate::on_child_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_child,
+            )
+        }
+        extern "C" fn on_window_changed<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+        ) {
+            let (arg_self_, arg_view, arg_added) = (self_, view, added);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            ImplViewDelegate::on_window_changed(&arg_self_.interface, arg_view, arg_added)
+        }
+        extern "C" fn on_layout_changed<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            new_bounds: *const _cef_rect_t,
+        ) {
+            let (arg_self_, arg_view, arg_new_bounds) = (self_, view, new_bounds);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_new_bounds = if arg_new_bounds.is_null() {
+                None
+            } else {
+                Some(WrapParamRef::<Rect, _>::from(arg_new_bounds))
+            };
+            let arg_new_bounds = arg_new_bounds.as_ref().map(|arg| arg.as_ref());
+            ImplViewDelegate::on_layout_changed(&arg_self_.interface, arg_view, arg_new_bounds)
+        }
+        extern "C" fn on_focus<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_focus(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_blur<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_blur(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_theme_changed<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_theme_changed(&arg_self_.interface, arg_view)
+        }
     }
 }
 impl ImplViewDelegate for TextfieldDelegate {
@@ -38059,7 +38607,7 @@ pub trait ImplBrowserViewDelegate: ImplViewDelegate {
         Default::default()
     }
     fn init_methods(object: &mut _cef_browser_view_delegate_t) {
-        impl_cef_view_delegate_t::init_methods::<Self>(&mut object.base);
+        impl_cef_browser_view_delegate_t::bridge_cef_view_delegate_t::init_methods::<Self>(object);
         impl_cef_browser_view_delegate_t::init_methods::<Self>(object);
     }
     fn get_raw(&self) -> *mut _cef_browser_view_delegate_t {
@@ -38244,6 +38792,179 @@ mod impl_cef_browser_view_delegate_t {
             &arg_self_.interface,
             arg_browser_view,
         )
+    }
+    pub(crate) mod bridge_cef_view_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplBrowserViewDelegate>(object: &mut _cef_browser_view_delegate_t) {
+            object.base.get_preferred_size = Some(get_preferred_size::<I>);
+            object.base.get_minimum_size = Some(get_minimum_size::<I>);
+            object.base.get_maximum_size = Some(get_maximum_size::<I>);
+            object.base.get_height_for_width = Some(get_height_for_width::<I>);
+            object.base.on_parent_view_changed = Some(on_parent_view_changed::<I>);
+            object.base.on_child_view_changed = Some(on_child_view_changed::<I>);
+            object.base.on_window_changed = Some(on_window_changed::<I>);
+            object.base.on_layout_changed = Some(on_layout_changed::<I>);
+            object.base.on_focus = Some(on_focus::<I>);
+            object.base.on_blur = Some(on_blur::<I>);
+            object.base.on_theme_changed = Some(on_theme_changed::<I>);
+        }
+        extern "C" fn get_preferred_size<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::preferred_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_minimum_size<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::minimum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_maximum_size<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::maximum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_height_for_width<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            width: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int {
+            let (arg_self_, arg_view, arg_width) = (self_, view, width);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_width = arg_width.into_raw();
+            ImplViewDelegate::height_for_width(&arg_self_.interface, arg_view, arg_width)
+        }
+        extern "C" fn on_parent_view_changed<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            parent: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_parent) = (self_, view, added, parent);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_parent =
+                unsafe { arg_parent.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_parent = arg_parent.as_mut();
+            ImplViewDelegate::on_parent_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_parent,
+            )
+        }
+        extern "C" fn on_child_view_changed<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            child: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_child) = (self_, view, added, child);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_child =
+                unsafe { arg_child.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_child = arg_child.as_mut();
+            ImplViewDelegate::on_child_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_child,
+            )
+        }
+        extern "C" fn on_window_changed<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+        ) {
+            let (arg_self_, arg_view, arg_added) = (self_, view, added);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            ImplViewDelegate::on_window_changed(&arg_self_.interface, arg_view, arg_added)
+        }
+        extern "C" fn on_layout_changed<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            new_bounds: *const _cef_rect_t,
+        ) {
+            let (arg_self_, arg_view, arg_new_bounds) = (self_, view, new_bounds);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_new_bounds = if arg_new_bounds.is_null() {
+                None
+            } else {
+                Some(WrapParamRef::<Rect, _>::from(arg_new_bounds))
+            };
+            let arg_new_bounds = arg_new_bounds.as_ref().map(|arg| arg.as_ref());
+            ImplViewDelegate::on_layout_changed(&arg_self_.interface, arg_view, arg_new_bounds)
+        }
+        extern "C" fn on_focus<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_focus(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_blur<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_blur(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_theme_changed<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_theme_changed(&arg_self_.interface, arg_view)
+        }
     }
 }
 impl ImplViewDelegate for BrowserViewDelegate {
@@ -39676,7 +40397,7 @@ pub trait WrapPanelDelegate: ImplPanelDelegate {
 }
 pub trait ImplPanelDelegate: ImplViewDelegate {
     fn init_methods(object: &mut _cef_panel_delegate_t) {
-        impl_cef_view_delegate_t::init_methods::<Self>(&mut object.base);
+        impl_cef_panel_delegate_t::bridge_cef_view_delegate_t::init_methods::<Self>(object);
         impl_cef_panel_delegate_t::init_methods::<Self>(object);
     }
     fn get_raw(&self) -> *mut _cef_panel_delegate_t {
@@ -39689,6 +40410,179 @@ macro_rules ! wrap_panel_delegate { ($ vis : vis struct $ name : ident ; impl Vi
 mod impl_cef_panel_delegate_t {
     use super::*;
     pub fn init_methods<I: ImplPanelDelegate>(object: &mut _cef_panel_delegate_t) {}
+    pub(crate) mod bridge_cef_view_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplPanelDelegate>(object: &mut _cef_panel_delegate_t) {
+            object.base.get_preferred_size = Some(get_preferred_size::<I>);
+            object.base.get_minimum_size = Some(get_minimum_size::<I>);
+            object.base.get_maximum_size = Some(get_maximum_size::<I>);
+            object.base.get_height_for_width = Some(get_height_for_width::<I>);
+            object.base.on_parent_view_changed = Some(on_parent_view_changed::<I>);
+            object.base.on_child_view_changed = Some(on_child_view_changed::<I>);
+            object.base.on_window_changed = Some(on_window_changed::<I>);
+            object.base.on_layout_changed = Some(on_layout_changed::<I>);
+            object.base.on_focus = Some(on_focus::<I>);
+            object.base.on_blur = Some(on_blur::<I>);
+            object.base.on_theme_changed = Some(on_theme_changed::<I>);
+        }
+        extern "C" fn get_preferred_size<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::preferred_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_minimum_size<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::minimum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_maximum_size<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::maximum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_height_for_width<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            width: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int {
+            let (arg_self_, arg_view, arg_width) = (self_, view, width);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_width = arg_width.into_raw();
+            ImplViewDelegate::height_for_width(&arg_self_.interface, arg_view, arg_width)
+        }
+        extern "C" fn on_parent_view_changed<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            parent: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_parent) = (self_, view, added, parent);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_parent =
+                unsafe { arg_parent.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_parent = arg_parent.as_mut();
+            ImplViewDelegate::on_parent_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_parent,
+            )
+        }
+        extern "C" fn on_child_view_changed<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            child: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_child) = (self_, view, added, child);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_child =
+                unsafe { arg_child.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_child = arg_child.as_mut();
+            ImplViewDelegate::on_child_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_child,
+            )
+        }
+        extern "C" fn on_window_changed<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+        ) {
+            let (arg_self_, arg_view, arg_added) = (self_, view, added);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            ImplViewDelegate::on_window_changed(&arg_self_.interface, arg_view, arg_added)
+        }
+        extern "C" fn on_layout_changed<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            new_bounds: *const _cef_rect_t,
+        ) {
+            let (arg_self_, arg_view, arg_new_bounds) = (self_, view, new_bounds);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_new_bounds = if arg_new_bounds.is_null() {
+                None
+            } else {
+                Some(WrapParamRef::<Rect, _>::from(arg_new_bounds))
+            };
+            let arg_new_bounds = arg_new_bounds.as_ref().map(|arg| arg.as_ref());
+            ImplViewDelegate::on_layout_changed(&arg_self_.interface, arg_view, arg_new_bounds)
+        }
+        extern "C" fn on_focus<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_focus(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_blur<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_blur(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_theme_changed<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_theme_changed(&arg_self_.interface, arg_view)
+        }
+    }
 }
 impl ImplViewDelegate for PanelDelegate {
     fn preferred_size(&self, view: Option<&mut View>) -> Size {
@@ -40347,8 +41241,8 @@ pub trait ImplWindowDelegate: ImplPanelDelegate {
         Default::default()
     }
     fn init_methods(object: &mut _cef_window_delegate_t) {
-        impl_cef_view_delegate_t::init_methods::<Self>(&mut object.base.base);
-        impl_cef_panel_delegate_t::init_methods::<Self>(&mut object.base);
+        impl_cef_window_delegate_t::bridge_cef_view_delegate_t::init_methods::<Self>(object);
+        impl_cef_window_delegate_t::bridge_cef_panel_delegate_t::init_methods::<Self>(object);
         impl_cef_window_delegate_t::init_methods::<Self>(object);
     }
     fn get_raw(&self) -> *mut _cef_window_delegate_t {
@@ -40720,6 +41614,183 @@ mod impl_cef_window_delegate_t {
             arg_window,
             arg_properties,
         )
+    }
+    pub(crate) mod bridge_cef_view_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplWindowDelegate>(object: &mut _cef_window_delegate_t) {
+            object.base.base.get_preferred_size = Some(get_preferred_size::<I>);
+            object.base.base.get_minimum_size = Some(get_minimum_size::<I>);
+            object.base.base.get_maximum_size = Some(get_maximum_size::<I>);
+            object.base.base.get_height_for_width = Some(get_height_for_width::<I>);
+            object.base.base.on_parent_view_changed = Some(on_parent_view_changed::<I>);
+            object.base.base.on_child_view_changed = Some(on_child_view_changed::<I>);
+            object.base.base.on_window_changed = Some(on_window_changed::<I>);
+            object.base.base.on_layout_changed = Some(on_layout_changed::<I>);
+            object.base.base.on_focus = Some(on_focus::<I>);
+            object.base.base.on_blur = Some(on_blur::<I>);
+            object.base.base.on_theme_changed = Some(on_theme_changed::<I>);
+        }
+        extern "C" fn get_preferred_size<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::preferred_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_minimum_size<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::minimum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_maximum_size<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::maximum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_height_for_width<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            width: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int {
+            let (arg_self_, arg_view, arg_width) = (self_, view, width);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_width = arg_width.into_raw();
+            ImplViewDelegate::height_for_width(&arg_self_.interface, arg_view, arg_width)
+        }
+        extern "C" fn on_parent_view_changed<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            parent: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_parent) = (self_, view, added, parent);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_parent =
+                unsafe { arg_parent.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_parent = arg_parent.as_mut();
+            ImplViewDelegate::on_parent_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_parent,
+            )
+        }
+        extern "C" fn on_child_view_changed<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            child: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_child) = (self_, view, added, child);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_child =
+                unsafe { arg_child.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_child = arg_child.as_mut();
+            ImplViewDelegate::on_child_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_child,
+            )
+        }
+        extern "C" fn on_window_changed<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+        ) {
+            let (arg_self_, arg_view, arg_added) = (self_, view, added);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            ImplViewDelegate::on_window_changed(&arg_self_.interface, arg_view, arg_added)
+        }
+        extern "C" fn on_layout_changed<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            new_bounds: *const _cef_rect_t,
+        ) {
+            let (arg_self_, arg_view, arg_new_bounds) = (self_, view, new_bounds);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_new_bounds = if arg_new_bounds.is_null() {
+                None
+            } else {
+                Some(WrapParamRef::<Rect, _>::from(arg_new_bounds))
+            };
+            let arg_new_bounds = arg_new_bounds.as_ref().map(|arg| arg.as_ref());
+            ImplViewDelegate::on_layout_changed(&arg_self_.interface, arg_view, arg_new_bounds)
+        }
+        extern "C" fn on_focus<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_focus(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_blur<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_blur(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_theme_changed<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_theme_changed(&arg_self_.interface, arg_view)
+        }
+    }
+    pub(crate) mod bridge_cef_panel_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplWindowDelegate>(object: &mut _cef_window_delegate_t) {}
     }
 }
 impl ImplViewDelegate for WindowDelegate {

--- a/cef/src/bindings/x86_64_unknown_linux_gnu.rs
+++ b/cef/src/bindings/x86_64_unknown_linux_gnu.rs
@@ -35957,7 +35957,7 @@ pub trait ImplButtonDelegate: ImplViewDelegate {
     #[doc = "See [`_cef_button_delegate_t::on_button_state_changed`] for more documentation."]
     fn on_button_state_changed(&self, button: Option<&mut Button>) {}
     fn init_methods(object: &mut _cef_button_delegate_t) {
-        impl_cef_view_delegate_t::init_methods::<Self>(&mut object.base);
+        impl_cef_button_delegate_t::bridge_cef_view_delegate_t::init_methods::<Self>(object);
         impl_cef_button_delegate_t::init_methods::<Self>(object);
     }
     fn get_raw(&self) -> *mut _cef_button_delegate_t {
@@ -35994,6 +35994,179 @@ mod impl_cef_button_delegate_t {
             unsafe { arg_button.as_mut() }.map(|arg| Button(unsafe { RefGuard::from_raw(arg) }));
         let arg_button = arg_button.as_mut();
         ImplButtonDelegate::on_button_state_changed(&arg_self_.interface, arg_button)
+    }
+    pub(crate) mod bridge_cef_view_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplButtonDelegate>(object: &mut _cef_button_delegate_t) {
+            object.base.get_preferred_size = Some(get_preferred_size::<I>);
+            object.base.get_minimum_size = Some(get_minimum_size::<I>);
+            object.base.get_maximum_size = Some(get_maximum_size::<I>);
+            object.base.get_height_for_width = Some(get_height_for_width::<I>);
+            object.base.on_parent_view_changed = Some(on_parent_view_changed::<I>);
+            object.base.on_child_view_changed = Some(on_child_view_changed::<I>);
+            object.base.on_window_changed = Some(on_window_changed::<I>);
+            object.base.on_layout_changed = Some(on_layout_changed::<I>);
+            object.base.on_focus = Some(on_focus::<I>);
+            object.base.on_blur = Some(on_blur::<I>);
+            object.base.on_theme_changed = Some(on_theme_changed::<I>);
+        }
+        extern "C" fn get_preferred_size<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::preferred_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_minimum_size<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::minimum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_maximum_size<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::maximum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_height_for_width<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            width: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int {
+            let (arg_self_, arg_view, arg_width) = (self_, view, width);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_width = arg_width.into_raw();
+            ImplViewDelegate::height_for_width(&arg_self_.interface, arg_view, arg_width)
+        }
+        extern "C" fn on_parent_view_changed<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            parent: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_parent) = (self_, view, added, parent);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_parent =
+                unsafe { arg_parent.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_parent = arg_parent.as_mut();
+            ImplViewDelegate::on_parent_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_parent,
+            )
+        }
+        extern "C" fn on_child_view_changed<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            child: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_child) = (self_, view, added, child);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_child =
+                unsafe { arg_child.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_child = arg_child.as_mut();
+            ImplViewDelegate::on_child_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_child,
+            )
+        }
+        extern "C" fn on_window_changed<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+        ) {
+            let (arg_self_, arg_view, arg_added) = (self_, view, added);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            ImplViewDelegate::on_window_changed(&arg_self_.interface, arg_view, arg_added)
+        }
+        extern "C" fn on_layout_changed<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            new_bounds: *const _cef_rect_t,
+        ) {
+            let (arg_self_, arg_view, arg_new_bounds) = (self_, view, new_bounds);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_new_bounds = if arg_new_bounds.is_null() {
+                None
+            } else {
+                Some(WrapParamRef::<Rect, _>::from(arg_new_bounds))
+            };
+            let arg_new_bounds = arg_new_bounds.as_ref().map(|arg| arg.as_ref());
+            ImplViewDelegate::on_layout_changed(&arg_self_.interface, arg_view, arg_new_bounds)
+        }
+        extern "C" fn on_focus<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_focus(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_blur<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_blur(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_theme_changed<I: ImplButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_theme_changed(&arg_self_.interface, arg_view)
+        }
     }
 }
 impl ImplViewDelegate for ButtonDelegate {
@@ -36615,8 +36788,8 @@ pub trait ImplMenuButtonDelegate: ImplButtonDelegate {
     ) {
     }
     fn init_methods(object: &mut _cef_menu_button_delegate_t) {
-        impl_cef_view_delegate_t::init_methods::<Self>(&mut object.base.base);
-        impl_cef_button_delegate_t::init_methods::<Self>(&mut object.base);
+        impl_cef_menu_button_delegate_t::bridge_cef_view_delegate_t::init_methods::<Self>(object);
+        impl_cef_menu_button_delegate_t::bridge_cef_button_delegate_t::init_methods::<Self>(object);
         impl_cef_menu_button_delegate_t::init_methods::<Self>(object);
     }
     fn get_raw(&self) -> *mut _cef_menu_button_delegate_t {
@@ -36658,6 +36831,208 @@ mod impl_cef_menu_button_delegate_t {
             arg_screen_point,
             arg_button_pressed_lock,
         )
+    }
+    pub(crate) mod bridge_cef_view_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplMenuButtonDelegate>(object: &mut _cef_menu_button_delegate_t) {
+            object.base.base.get_preferred_size = Some(get_preferred_size::<I>);
+            object.base.base.get_minimum_size = Some(get_minimum_size::<I>);
+            object.base.base.get_maximum_size = Some(get_maximum_size::<I>);
+            object.base.base.get_height_for_width = Some(get_height_for_width::<I>);
+            object.base.base.on_parent_view_changed = Some(on_parent_view_changed::<I>);
+            object.base.base.on_child_view_changed = Some(on_child_view_changed::<I>);
+            object.base.base.on_window_changed = Some(on_window_changed::<I>);
+            object.base.base.on_layout_changed = Some(on_layout_changed::<I>);
+            object.base.base.on_focus = Some(on_focus::<I>);
+            object.base.base.on_blur = Some(on_blur::<I>);
+            object.base.base.on_theme_changed = Some(on_theme_changed::<I>);
+        }
+        extern "C" fn get_preferred_size<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::preferred_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_minimum_size<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::minimum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_maximum_size<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::maximum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_height_for_width<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            width: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int {
+            let (arg_self_, arg_view, arg_width) = (self_, view, width);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_width = arg_width.into_raw();
+            ImplViewDelegate::height_for_width(&arg_self_.interface, arg_view, arg_width)
+        }
+        extern "C" fn on_parent_view_changed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            parent: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_parent) = (self_, view, added, parent);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_parent =
+                unsafe { arg_parent.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_parent = arg_parent.as_mut();
+            ImplViewDelegate::on_parent_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_parent,
+            )
+        }
+        extern "C" fn on_child_view_changed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            child: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_child) = (self_, view, added, child);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_child =
+                unsafe { arg_child.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_child = arg_child.as_mut();
+            ImplViewDelegate::on_child_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_child,
+            )
+        }
+        extern "C" fn on_window_changed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+        ) {
+            let (arg_self_, arg_view, arg_added) = (self_, view, added);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            ImplViewDelegate::on_window_changed(&arg_self_.interface, arg_view, arg_added)
+        }
+        extern "C" fn on_layout_changed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            new_bounds: *const _cef_rect_t,
+        ) {
+            let (arg_self_, arg_view, arg_new_bounds) = (self_, view, new_bounds);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_new_bounds = if arg_new_bounds.is_null() {
+                None
+            } else {
+                Some(WrapParamRef::<Rect, _>::from(arg_new_bounds))
+            };
+            let arg_new_bounds = arg_new_bounds.as_ref().map(|arg| arg.as_ref());
+            ImplViewDelegate::on_layout_changed(&arg_self_.interface, arg_view, arg_new_bounds)
+        }
+        extern "C" fn on_focus<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_focus(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_blur<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_blur(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_theme_changed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_theme_changed(&arg_self_.interface, arg_view)
+        }
+    }
+    pub(crate) mod bridge_cef_button_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplMenuButtonDelegate>(object: &mut _cef_menu_button_delegate_t) {
+            object.base.on_button_pressed = Some(on_button_pressed::<I>);
+            object.base.on_button_state_changed = Some(on_button_state_changed::<I>);
+        }
+        extern "C" fn on_button_pressed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_button_delegate_t,
+            button: *mut _cef_button_t,
+        ) {
+            let (arg_self_, arg_button) = (self_, button);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_button = unsafe { arg_button.as_mut() }
+                .map(|arg| Button(unsafe { RefGuard::from_raw(arg) }));
+            let arg_button = arg_button.as_mut();
+            ImplButtonDelegate::on_button_pressed(&arg_self_.interface, arg_button)
+        }
+        extern "C" fn on_button_state_changed<I: ImplMenuButtonDelegate>(
+            self_: *mut _cef_button_delegate_t,
+            button: *mut _cef_button_t,
+        ) {
+            let (arg_self_, arg_button) = (self_, button);
+            let arg_self_: &RcImpl<_cef_menu_button_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_button = unsafe { arg_button.as_mut() }
+                .map(|arg| Button(unsafe { RefGuard::from_raw(arg) }));
+            let arg_button = arg_button.as_mut();
+            ImplButtonDelegate::on_button_state_changed(&arg_self_.interface, arg_button)
+        }
     }
 }
 impl ImplViewDelegate for MenuButtonDelegate {
@@ -37184,7 +37559,7 @@ pub trait ImplTextfieldDelegate: ImplViewDelegate {
     #[doc = "See [`_cef_textfield_delegate_t::on_after_user_action`] for more documentation."]
     fn on_after_user_action(&self, textfield: Option<&mut Textfield>) {}
     fn init_methods(object: &mut _cef_textfield_delegate_t) {
-        impl_cef_view_delegate_t::init_methods::<Self>(&mut object.base);
+        impl_cef_textfield_delegate_t::bridge_cef_view_delegate_t::init_methods::<Self>(object);
         impl_cef_textfield_delegate_t::init_methods::<Self>(object);
     }
     fn get_raw(&self) -> *mut _cef_textfield_delegate_t {
@@ -37228,6 +37603,179 @@ mod impl_cef_textfield_delegate_t {
             .map(|arg| Textfield(unsafe { RefGuard::from_raw(arg) }));
         let arg_textfield = arg_textfield.as_mut();
         ImplTextfieldDelegate::on_after_user_action(&arg_self_.interface, arg_textfield)
+    }
+    pub(crate) mod bridge_cef_view_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplTextfieldDelegate>(object: &mut _cef_textfield_delegate_t) {
+            object.base.get_preferred_size = Some(get_preferred_size::<I>);
+            object.base.get_minimum_size = Some(get_minimum_size::<I>);
+            object.base.get_maximum_size = Some(get_maximum_size::<I>);
+            object.base.get_height_for_width = Some(get_height_for_width::<I>);
+            object.base.on_parent_view_changed = Some(on_parent_view_changed::<I>);
+            object.base.on_child_view_changed = Some(on_child_view_changed::<I>);
+            object.base.on_window_changed = Some(on_window_changed::<I>);
+            object.base.on_layout_changed = Some(on_layout_changed::<I>);
+            object.base.on_focus = Some(on_focus::<I>);
+            object.base.on_blur = Some(on_blur::<I>);
+            object.base.on_theme_changed = Some(on_theme_changed::<I>);
+        }
+        extern "C" fn get_preferred_size<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::preferred_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_minimum_size<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::minimum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_maximum_size<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::maximum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_height_for_width<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            width: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int {
+            let (arg_self_, arg_view, arg_width) = (self_, view, width);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_width = arg_width.into_raw();
+            ImplViewDelegate::height_for_width(&arg_self_.interface, arg_view, arg_width)
+        }
+        extern "C" fn on_parent_view_changed<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            parent: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_parent) = (self_, view, added, parent);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_parent =
+                unsafe { arg_parent.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_parent = arg_parent.as_mut();
+            ImplViewDelegate::on_parent_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_parent,
+            )
+        }
+        extern "C" fn on_child_view_changed<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            child: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_child) = (self_, view, added, child);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_child =
+                unsafe { arg_child.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_child = arg_child.as_mut();
+            ImplViewDelegate::on_child_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_child,
+            )
+        }
+        extern "C" fn on_window_changed<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+        ) {
+            let (arg_self_, arg_view, arg_added) = (self_, view, added);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            ImplViewDelegate::on_window_changed(&arg_self_.interface, arg_view, arg_added)
+        }
+        extern "C" fn on_layout_changed<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            new_bounds: *const _cef_rect_t,
+        ) {
+            let (arg_self_, arg_view, arg_new_bounds) = (self_, view, new_bounds);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_new_bounds = if arg_new_bounds.is_null() {
+                None
+            } else {
+                Some(WrapParamRef::<Rect, _>::from(arg_new_bounds))
+            };
+            let arg_new_bounds = arg_new_bounds.as_ref().map(|arg| arg.as_ref());
+            ImplViewDelegate::on_layout_changed(&arg_self_.interface, arg_view, arg_new_bounds)
+        }
+        extern "C" fn on_focus<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_focus(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_blur<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_blur(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_theme_changed<I: ImplTextfieldDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_textfield_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_theme_changed(&arg_self_.interface, arg_view)
+        }
     }
 }
 impl ImplViewDelegate for TextfieldDelegate {
@@ -38097,7 +38645,7 @@ pub trait ImplBrowserViewDelegate: ImplViewDelegate {
         Default::default()
     }
     fn init_methods(object: &mut _cef_browser_view_delegate_t) {
-        impl_cef_view_delegate_t::init_methods::<Self>(&mut object.base);
+        impl_cef_browser_view_delegate_t::bridge_cef_view_delegate_t::init_methods::<Self>(object);
         impl_cef_browser_view_delegate_t::init_methods::<Self>(object);
     }
     fn get_raw(&self) -> *mut _cef_browser_view_delegate_t {
@@ -38282,6 +38830,179 @@ mod impl_cef_browser_view_delegate_t {
             &arg_self_.interface,
             arg_browser_view,
         )
+    }
+    pub(crate) mod bridge_cef_view_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplBrowserViewDelegate>(object: &mut _cef_browser_view_delegate_t) {
+            object.base.get_preferred_size = Some(get_preferred_size::<I>);
+            object.base.get_minimum_size = Some(get_minimum_size::<I>);
+            object.base.get_maximum_size = Some(get_maximum_size::<I>);
+            object.base.get_height_for_width = Some(get_height_for_width::<I>);
+            object.base.on_parent_view_changed = Some(on_parent_view_changed::<I>);
+            object.base.on_child_view_changed = Some(on_child_view_changed::<I>);
+            object.base.on_window_changed = Some(on_window_changed::<I>);
+            object.base.on_layout_changed = Some(on_layout_changed::<I>);
+            object.base.on_focus = Some(on_focus::<I>);
+            object.base.on_blur = Some(on_blur::<I>);
+            object.base.on_theme_changed = Some(on_theme_changed::<I>);
+        }
+        extern "C" fn get_preferred_size<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::preferred_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_minimum_size<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::minimum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_maximum_size<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::maximum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_height_for_width<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            width: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int {
+            let (arg_self_, arg_view, arg_width) = (self_, view, width);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_width = arg_width.into_raw();
+            ImplViewDelegate::height_for_width(&arg_self_.interface, arg_view, arg_width)
+        }
+        extern "C" fn on_parent_view_changed<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            parent: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_parent) = (self_, view, added, parent);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_parent =
+                unsafe { arg_parent.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_parent = arg_parent.as_mut();
+            ImplViewDelegate::on_parent_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_parent,
+            )
+        }
+        extern "C" fn on_child_view_changed<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            child: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_child) = (self_, view, added, child);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_child =
+                unsafe { arg_child.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_child = arg_child.as_mut();
+            ImplViewDelegate::on_child_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_child,
+            )
+        }
+        extern "C" fn on_window_changed<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+        ) {
+            let (arg_self_, arg_view, arg_added) = (self_, view, added);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            ImplViewDelegate::on_window_changed(&arg_self_.interface, arg_view, arg_added)
+        }
+        extern "C" fn on_layout_changed<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            new_bounds: *const _cef_rect_t,
+        ) {
+            let (arg_self_, arg_view, arg_new_bounds) = (self_, view, new_bounds);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_new_bounds = if arg_new_bounds.is_null() {
+                None
+            } else {
+                Some(WrapParamRef::<Rect, _>::from(arg_new_bounds))
+            };
+            let arg_new_bounds = arg_new_bounds.as_ref().map(|arg| arg.as_ref());
+            ImplViewDelegate::on_layout_changed(&arg_self_.interface, arg_view, arg_new_bounds)
+        }
+        extern "C" fn on_focus<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_focus(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_blur<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_blur(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_theme_changed<I: ImplBrowserViewDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_browser_view_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_theme_changed(&arg_self_.interface, arg_view)
+        }
     }
 }
 impl ImplViewDelegate for BrowserViewDelegate {
@@ -39714,7 +40435,7 @@ pub trait WrapPanelDelegate: ImplPanelDelegate {
 }
 pub trait ImplPanelDelegate: ImplViewDelegate {
     fn init_methods(object: &mut _cef_panel_delegate_t) {
-        impl_cef_view_delegate_t::init_methods::<Self>(&mut object.base);
+        impl_cef_panel_delegate_t::bridge_cef_view_delegate_t::init_methods::<Self>(object);
         impl_cef_panel_delegate_t::init_methods::<Self>(object);
     }
     fn get_raw(&self) -> *mut _cef_panel_delegate_t {
@@ -39727,6 +40448,179 @@ macro_rules ! wrap_panel_delegate { ($ vis : vis struct $ name : ident ; impl Vi
 mod impl_cef_panel_delegate_t {
     use super::*;
     pub fn init_methods<I: ImplPanelDelegate>(object: &mut _cef_panel_delegate_t) {}
+    pub(crate) mod bridge_cef_view_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplPanelDelegate>(object: &mut _cef_panel_delegate_t) {
+            object.base.get_preferred_size = Some(get_preferred_size::<I>);
+            object.base.get_minimum_size = Some(get_minimum_size::<I>);
+            object.base.get_maximum_size = Some(get_maximum_size::<I>);
+            object.base.get_height_for_width = Some(get_height_for_width::<I>);
+            object.base.on_parent_view_changed = Some(on_parent_view_changed::<I>);
+            object.base.on_child_view_changed = Some(on_child_view_changed::<I>);
+            object.base.on_window_changed = Some(on_window_changed::<I>);
+            object.base.on_layout_changed = Some(on_layout_changed::<I>);
+            object.base.on_focus = Some(on_focus::<I>);
+            object.base.on_blur = Some(on_blur::<I>);
+            object.base.on_theme_changed = Some(on_theme_changed::<I>);
+        }
+        extern "C" fn get_preferred_size<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::preferred_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_minimum_size<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::minimum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_maximum_size<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::maximum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_height_for_width<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            width: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int {
+            let (arg_self_, arg_view, arg_width) = (self_, view, width);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_width = arg_width.into_raw();
+            ImplViewDelegate::height_for_width(&arg_self_.interface, arg_view, arg_width)
+        }
+        extern "C" fn on_parent_view_changed<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            parent: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_parent) = (self_, view, added, parent);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_parent =
+                unsafe { arg_parent.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_parent = arg_parent.as_mut();
+            ImplViewDelegate::on_parent_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_parent,
+            )
+        }
+        extern "C" fn on_child_view_changed<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            child: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_child) = (self_, view, added, child);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_child =
+                unsafe { arg_child.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_child = arg_child.as_mut();
+            ImplViewDelegate::on_child_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_child,
+            )
+        }
+        extern "C" fn on_window_changed<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+        ) {
+            let (arg_self_, arg_view, arg_added) = (self_, view, added);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            ImplViewDelegate::on_window_changed(&arg_self_.interface, arg_view, arg_added)
+        }
+        extern "C" fn on_layout_changed<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            new_bounds: *const _cef_rect_t,
+        ) {
+            let (arg_self_, arg_view, arg_new_bounds) = (self_, view, new_bounds);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_new_bounds = if arg_new_bounds.is_null() {
+                None
+            } else {
+                Some(WrapParamRef::<Rect, _>::from(arg_new_bounds))
+            };
+            let arg_new_bounds = arg_new_bounds.as_ref().map(|arg| arg.as_ref());
+            ImplViewDelegate::on_layout_changed(&arg_self_.interface, arg_view, arg_new_bounds)
+        }
+        extern "C" fn on_focus<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_focus(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_blur<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_blur(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_theme_changed<I: ImplPanelDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_panel_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_theme_changed(&arg_self_.interface, arg_view)
+        }
+    }
 }
 impl ImplViewDelegate for PanelDelegate {
     fn preferred_size(&self, view: Option<&mut View>) -> Size {
@@ -40385,8 +41279,8 @@ pub trait ImplWindowDelegate: ImplPanelDelegate {
         Default::default()
     }
     fn init_methods(object: &mut _cef_window_delegate_t) {
-        impl_cef_view_delegate_t::init_methods::<Self>(&mut object.base.base);
-        impl_cef_panel_delegate_t::init_methods::<Self>(&mut object.base);
+        impl_cef_window_delegate_t::bridge_cef_view_delegate_t::init_methods::<Self>(object);
+        impl_cef_window_delegate_t::bridge_cef_panel_delegate_t::init_methods::<Self>(object);
         impl_cef_window_delegate_t::init_methods::<Self>(object);
     }
     fn get_raw(&self) -> *mut _cef_window_delegate_t {
@@ -40758,6 +41652,183 @@ mod impl_cef_window_delegate_t {
             arg_window,
             arg_properties,
         )
+    }
+    pub(crate) mod bridge_cef_view_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplWindowDelegate>(object: &mut _cef_window_delegate_t) {
+            object.base.base.get_preferred_size = Some(get_preferred_size::<I>);
+            object.base.base.get_minimum_size = Some(get_minimum_size::<I>);
+            object.base.base.get_maximum_size = Some(get_maximum_size::<I>);
+            object.base.base.get_height_for_width = Some(get_height_for_width::<I>);
+            object.base.base.on_parent_view_changed = Some(on_parent_view_changed::<I>);
+            object.base.base.on_child_view_changed = Some(on_child_view_changed::<I>);
+            object.base.base.on_window_changed = Some(on_window_changed::<I>);
+            object.base.base.on_layout_changed = Some(on_layout_changed::<I>);
+            object.base.base.on_focus = Some(on_focus::<I>);
+            object.base.base.on_blur = Some(on_blur::<I>);
+            object.base.base.on_theme_changed = Some(on_theme_changed::<I>);
+        }
+        extern "C" fn get_preferred_size<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::preferred_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_minimum_size<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::minimum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_maximum_size<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) -> _cef_size_t {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let result = ImplViewDelegate::maximum_size(&arg_self_.interface, arg_view);
+            result.into()
+        }
+        extern "C" fn get_height_for_width<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            width: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int {
+            let (arg_self_, arg_view, arg_width) = (self_, view, width);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_width = arg_width.into_raw();
+            ImplViewDelegate::height_for_width(&arg_self_.interface, arg_view, arg_width)
+        }
+        extern "C" fn on_parent_view_changed<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            parent: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_parent) = (self_, view, added, parent);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_parent =
+                unsafe { arg_parent.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_parent = arg_parent.as_mut();
+            ImplViewDelegate::on_parent_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_parent,
+            )
+        }
+        extern "C" fn on_child_view_changed<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+            child: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view, arg_added, arg_child) = (self_, view, added, child);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            let mut arg_child =
+                unsafe { arg_child.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_child = arg_child.as_mut();
+            ImplViewDelegate::on_child_view_changed(
+                &arg_self_.interface,
+                arg_view,
+                arg_added,
+                arg_child,
+            )
+        }
+        extern "C" fn on_window_changed<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            added: ::std::os::raw::c_int,
+        ) {
+            let (arg_self_, arg_view, arg_added) = (self_, view, added);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_added = arg_added.into_raw();
+            ImplViewDelegate::on_window_changed(&arg_self_.interface, arg_view, arg_added)
+        }
+        extern "C" fn on_layout_changed<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+            new_bounds: *const _cef_rect_t,
+        ) {
+            let (arg_self_, arg_view, arg_new_bounds) = (self_, view, new_bounds);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            let arg_new_bounds = if arg_new_bounds.is_null() {
+                None
+            } else {
+                Some(WrapParamRef::<Rect, _>::from(arg_new_bounds))
+            };
+            let arg_new_bounds = arg_new_bounds.as_ref().map(|arg| arg.as_ref());
+            ImplViewDelegate::on_layout_changed(&arg_self_.interface, arg_view, arg_new_bounds)
+        }
+        extern "C" fn on_focus<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_focus(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_blur<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_blur(&arg_self_.interface, arg_view)
+        }
+        extern "C" fn on_theme_changed<I: ImplWindowDelegate>(
+            self_: *mut _cef_view_delegate_t,
+            view: *mut _cef_view_t,
+        ) {
+            let (arg_self_, arg_view) = (self_, view);
+            let arg_self_: &RcImpl<_cef_window_delegate_t, I> = RcImpl::get(arg_self_.cast());
+            let mut arg_view =
+                unsafe { arg_view.as_mut() }.map(|arg| View(unsafe { RefGuard::from_raw(arg) }));
+            let arg_view = arg_view.as_mut();
+            ImplViewDelegate::on_theme_changed(&arg_self_.interface, arg_view)
+        }
+    }
+    pub(crate) mod bridge_cef_panel_delegate_t {
+        use super::*;
+        pub fn init_methods<I: ImplWindowDelegate>(object: &mut _cef_window_delegate_t) {}
     }
 }
 impl ImplViewDelegate for WindowDelegate {

--- a/update-bindings/src/parse_tree.rs
+++ b/update-bindings/src/parse_tree.rs
@@ -724,6 +724,292 @@ impl SignatureRef<'_> {
         }
     }
 
+    fn wrap_cef_args_with_outer(
+        &self,
+        tree: &ParseTree,
+        outer_ident: &syn::Ident,
+    ) -> proc_macro2::TokenStream {
+        let capture = self.capture_params();
+        let args = self.merge_params(tree).filter_map(|arg| match arg {
+            MergedParam::Receiver => Some(quote! {
+                let arg_self_: &RcImpl<#outer_ident, I> = RcImpl::get(arg_self_.cast());
+            }),
+            MergedParam::Single {
+                name,
+                ty: Some(arg_ty),
+            } => {
+                let arg_name = format_ident!("arg_{name}");
+                let out_name = format_ident!("out_{name}");
+                let wrap_name = format_ident!("wrap_{name}");
+                let (modifiers, arg_ty) = (arg_ty.modifiers.as_slice(), &arg_ty.ty);
+                let ty_tokens = arg_ty.to_token_stream();
+                let ty_string = ty_tokens.to_string();
+                let entry = tree.cef_name_map.get(ty_string.as_str());
+                let root = tree.root(&ty_string);
+
+                (root == BASE_REF_COUNTED)
+                    .then(|| {
+                        match entry? {
+                            NameMapEntry {
+                                name,
+                                ty: NameMapType::StructDeclaration(_),
+                            } => {
+                                let name = format_ident!("{name}");
+
+                                match modifiers {
+                                    [TypeModifier::ConstPtr] => Some(quote! {
+                                        let #arg_name = unsafe { #arg_name.as_ref() }.map(|arg| {
+                                            #name(unsafe { RefGuard::from_raw(arg) })
+                                        });
+                                        let #arg_name = #arg_name.as_ref();
+                                    }),
+                                    [TypeModifier::MutPtr] => Some(quote! {
+                                        let mut #arg_name = unsafe { #arg_name.as_mut() }.map(|arg| {
+                                            #name(unsafe { RefGuard::from_raw(arg) })
+                                        });
+                                        let #arg_name = #arg_name.as_mut();
+                                    }),
+                                    [TypeModifier::MutPtr, TypeModifier::MutPtr] => Some(quote! {
+                                        let #out_name = #arg_name;
+                                        let mut #wrap_name = unsafe { #arg_name.as_mut() }.and_then(|ptr| {
+                                            if ptr.is_null() {
+                                                None
+                                            } else {
+                                                Some(#name(unsafe { RefGuard::from_raw(*ptr) }))
+                                            }
+                                        });
+                                        let #arg_name = Some(&mut #wrap_name);
+                                    }),
+                                    _ => None,
+                                }
+                            }
+                            _ => None,
+                        }
+                    })
+                    .flatten()
+                    .or_else(|| {
+                        if root == BASE_SCOPED {
+                            let Some(NameMapEntry { name, ty: NameMapType::StructDeclaration(_) }) = entry else {
+                                return None;
+                            };
+                            let name = format_ident!("{name}");
+                            match modifiers {
+                                [TypeModifier::MutPtr] => Some(quote! {
+                                    let mut #arg_name = if #arg_name.is_null() { None } else { Some(#name(#arg_name)) };
+                                    let #arg_name = #arg_name.as_mut();
+                                }),
+                                [TypeModifier::ConstPtr] => Some(quote! {
+                                    let #arg_name = if #arg_name.is_null() { None } else { Some(#name(#arg_name)) };
+                                    let #arg_name = #arg_name.as_ref();
+                                }),
+                                _ => None,
+                            }
+                        } else if ty_string.as_str() == "cef_string_t" ||
+                            CUSTOM_STRING_TYPES.contains(&ty_string.as_str())
+                        {
+                            match modifiers {
+                                [TypeModifier::MutPtr] => Some(quote! {
+                                    let mut #arg_name = if #arg_name.is_null() { None } else { Some(#arg_name.into()) };
+                                    let #arg_name = #arg_name.as_mut();
+                                }),
+                                [TypeModifier::ConstPtr] => Some(quote! {
+                                    let #arg_name = if #arg_name.is_null() { None } else { Some(#arg_name.into()) };
+                                    let #arg_name = #arg_name.as_ref();
+                                }),
+                                _ => None,
+                            }
+                        } else {
+                            let ty = entry.and_then(|entry| syn::parse_str::<syn::Type>(&entry.name).ok());
+                            let ty = ty.as_ref().unwrap_or(arg_ty).to_token_stream();
+
+                            if ty.to_string() == quote!{ ::std::os::raw::c_void }.to_string() {
+                                match modifiers {
+                                    [TypeModifier::MutPtr] => Some(quote! {
+                                        let #arg_name = #arg_name.cast();
+                                    }),
+                                    [TypeModifier::ConstPtr] => Some(quote! {
+                                        let #arg_name = #arg_name.cast();
+                                    }),
+                                    _ => {
+                                        Some(quote! {})
+                                    }
+                                }
+                            } else {
+                                match modifiers {
+                                    [TypeModifier::MutPtr] => Some(quote! {
+                                        let mut #arg_name = if #arg_name.is_null() {
+                                            None
+                                        } else {
+                                            Some(WrapParamRef::<#ty, _>::from(#arg_name))
+                                        };
+                                        let #arg_name = #arg_name.as_mut().map(|arg| arg.as_mut());
+                                    }),
+                                    [TypeModifier::ConstPtr] => Some(quote! {
+                                        let #arg_name = if #arg_name.is_null() {
+                                            None
+                                        } else {
+                                            Some(WrapParamRef::<#ty, _>::from(#arg_name))
+                                        };
+                                        let #arg_name = #arg_name.as_ref().map(|arg| arg.as_ref());
+                                    }),
+                                    _ => None,
+                                }
+                            }
+                        }
+                    })
+                    .or(Some(quote! { let #arg_name = #arg_name.into_raw(); }))
+            }
+            MergedParam::Bounded {
+                count_name,
+                slice_name,
+                slice_ty,
+                ..
+            } => {
+                let out_count = format_ident!("out_{count_name}");
+                let arg_count = format_ident!("arg_{count_name}");
+                let out_name = format_ident!("out_{slice_name}");
+                let arg_name = format_ident!("arg_{slice_name}");
+                let vec_name = format_ident!("vec_{slice_name}");
+
+                let (modifiers, slice_ty) = (slice_ty.modifiers.as_slice(), &slice_ty.ty);
+                let ty_tokens = slice_ty.to_token_stream();
+                let ty_string = ty_tokens.to_string();
+                let entry = tree.cef_name_map.get(ty_string.as_str());
+
+                (tree.root(&ty_string) == BASE_REF_COUNTED)
+                    .then(|| {
+                        match entry? {
+                            NameMapEntry {
+                                name,
+                                ty: NameMapType::StructDeclaration(_),
+                            } => {
+                                let name = format_ident!("{name}");
+
+                                match modifiers {
+                                    [TypeModifier::Slice] => {
+                                        Some(quote! {
+                                            let #vec_name = unsafe { #arg_name.as_ref() }.map(|arg| {
+                                                let arg = unsafe { std::slice::from_raw_parts(std::ptr::from_ref(arg), #arg_count) };
+                                                arg.iter()
+                                                    .map(|arg| {
+                                                        if arg.is_null() {
+                                                            None
+                                                        } else {
+                                                            Some(#name(unsafe { RefGuard::from_raw(*arg) }))
+                                                        }
+                                                    })
+                                                    .collect::<Vec<_>>()
+                                            });
+                                            let #arg_name = #vec_name.as_deref();
+                                        })
+                                    },
+                                    [TypeModifier::MutSlice] => {
+                                        Some(quote! {
+                                            let #out_count = unsafe { #arg_count.as_mut() };
+                                            let #out_name = unsafe { #arg_name.as_mut() };
+                                            let #arg_count = #out_count
+                                                .as_ref()
+                                                .map(|count| **count)
+                                                .unwrap_or_default();
+                                            let mut #vec_name = unsafe { #arg_name.as_mut() }.map(|arg| {
+                                                let arg = unsafe { std::slice::from_raw_parts_mut(std::ptr::from_mut(arg), #arg_count) };
+                                                arg.iter_mut()
+                                                    .map(|arg| {
+                                                        if arg.is_null() {
+                                                            None
+                                                        } else {
+                                                            Some(#name(unsafe { RefGuard::from_raw(*arg) }))
+                                                        }
+                                                    })
+                                                    .collect::<Vec<_>>()
+                                            });
+                                            let #arg_name = #vec_name.as_mut();
+                                        })
+                                    },
+                                    _ => None,
+                                }
+                            }
+                            _ => None,
+                        }
+                    })
+                    .flatten()
+                    .or_else(|| {
+                        if ty_string.as_str() == "cef_string_t" ||
+                            CUSTOM_STRING_TYPES.contains(&ty_string.as_str())
+                        {
+                            None
+                        } else {
+                            let ty =
+                                entry.and_then(|entry| syn::parse_str::<syn::Type>(&entry.name).ok());
+                            let ty = ty.as_ref().unwrap_or(slice_ty).to_token_stream();
+
+                            match modifiers {
+                                [TypeModifier::MutPtr, ..] => Some(quote! {
+                                    let mut #arg_name = WrapParamRef::<#ty, _>::from(#arg_name);
+                                    let #arg_name = #arg_name.as_mut();
+                                }),
+                                [TypeModifier::ConstPtr, ..] => Some(quote! {
+                                    let #arg_name = WrapParamRef::<#ty, _>::from(#arg_name);
+                                    let #arg_name = #arg_name.as_ref();
+                                }),
+                                _ => None,
+                            }
+                        }
+                    })
+                    .or(Some(quote! { let #arg_name = #arg_name.into_raw(); }))
+            }
+            MergedParam::Buffer {
+                slice_name,
+                slice_ty: ModifiedType { modifiers: slice_modifiers, .. },
+                size_name,
+                size_ty:
+                    ModifiedType {
+                        modifiers: size_modifiers,
+                        ..
+                    },
+            } => {
+                let out_name = format_ident!("out_{slice_name}");
+                let arg_name = format_ident!("arg_{slice_name}");
+                let vec_name = format_ident!("vec_{slice_name}");
+                let out_size = format_ident!("out_{size_name}");
+                let arg_size = format_ident!("arg_{size_name}");
+                match slice_modifiers.as_slice() {
+                    [TypeModifier::Slice] => Some(quote! {
+                        let #arg_name = (!#arg_name.is_null() && #arg_size > 0).then(|| unsafe {
+                            std::slice::from_raw_parts(#arg_name.cast(), #arg_size)
+                        });
+                    }),
+                    [TypeModifier::MutSlice] => {
+                        let out_size = match size_modifiers.as_slice() {
+                            [TypeModifier::MutPtr] => Some(quote! {
+                                let #out_size = unsafe { #arg_size.as_mut() };
+                                let #arg_size = #out_size.as_ref().map(|size| **size).unwrap_or_default();
+                            }),
+                            _ => None,
+                        };
+
+                        Some(quote! {
+                            #out_size
+                            let #out_name = (!#arg_name.is_null() && #arg_size > 0).then(|| unsafe {
+                                std::slice::from_raw_parts_mut(#arg_name.cast(), #arg_size)
+                            });
+                            let mut #vec_name = #out_name.as_ref().map(|arg| arg.to_vec());
+                            let #arg_name = #vec_name.as_mut();
+                        })
+                    }
+                    _ => None,
+                }
+                .or(Some(quote! { let #arg_name = #arg_name.into_raw(); }))
+            }
+            _ => None,
+        });
+
+        quote! {
+            #capture
+            #(#args)*
+        }
+    }
+
     fn rewrap_rust_args(&self, tree: &ParseTree) -> proc_macro2::TokenStream {
         let args = self.merge_params(tree).filter_map(|arg| match arg {
             MergedParam::Single {
@@ -2271,21 +2557,7 @@ impl ParseTree<'_> {
             base_structs.push(next_base);
         }
 
-        let init_bases = base_structs
-            .iter()
-            .enumerate()
-            .map(|(i, base_struct)| {
-                let name = &base_struct.name;
-                let name = format_ident!("{name}");
-                let impl_mod = format_ident!("impl{name}");
-                let bases = iter::repeat_n(format_ident!("base"), i + 1);
-                quote! {
-                    #impl_mod::init_methods::<Self>(&mut object.#(#bases).*);
-                }
-            })
-            .collect::<Vec<_>>()
-            .into_iter()
-            .rev();
+        // bridge_inits and bridge_modules are defined after impl_mod for clarity
 
         let impl_bases = base_structs
             .iter()
@@ -2535,6 +2807,129 @@ fn make_my_struct() -> {rust_name} {{
             }
         });
 
+        let bridge_inits = base_structs
+            .iter()
+            .enumerate()
+            .map(|(_i, base_struct)| {
+                let module_suffix = base_struct.name.trim_start_matches('_');
+                let bridge_mod = format_ident!("bridge_{}", module_suffix);
+                quote! {
+                    #impl_mod::#bridge_mod::init_methods::<Self>(object);
+                }
+            })
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev();
+
+        let bridge_modules = base_structs
+            .iter()
+            .enumerate()
+            .filter_map(|(i, base_struct)| {
+                self.cef_name_map.get(&base_struct.name).map(|entry| {
+                    let base_trait_ident = format_ident!("Impl{}", &entry.name);
+                    let init_methods = base_struct.methods.iter().map(|m| {
+                        let bases_path = iter::repeat_n(format_ident!("base"), i + 1);
+                        let field = format_ident!("{}", &m.name);
+                        let fn_name = format_ident!("{}", &m.name);
+                        quote! {
+                            object.#(#bases_path).* .#field = Some(#fn_name::<I>);
+                        }
+                    });
+
+                    let wrapped_methods = base_struct.methods.iter().map(|m| {
+                        let name = &m.name;
+                        let rust_method_name = make_rust_method_name(name);
+                        let name = format_ident!("{name}");
+                        let rust_method_name = format_ident!("{rust_method_name}");
+                        let args = m.inputs.iter().map(|arg| {
+                            let name = make_snake_case_value_name(&arg.name);
+                            let name = format_ident!("{name}");
+                            let ty = self.resolve_type_aliases(arg.ty);
+                            quote! { #name: #ty }
+                        });
+                        let wrapped_args = m.wrap_cef_args_with_outer(self, &name_ident);
+                        let unwrapped_args = m.unwrap_cef_args(self);
+                        let forward_args = m.merge_params(self).filter_map(|arg| match arg {
+                            MergedParam::Single { name, .. } => {
+                                let name = format_ident!("arg_{name}");
+                                Some(quote! { #name })
+                            }
+                            MergedParam::Bounded { slice_name, .. }
+                            | MergedParam::Buffer { slice_name, .. } => {
+                                let name = format_ident!("arg_{slice_name}");
+                                Some(quote! { #name })
+                            }
+                            _ => None,
+                        });
+                        let original_output = m.output.map(|ty| self.resolve_type_aliases(ty));
+                        let output = original_output.as_ref().map(|output| {
+                            quote! { -> #output }
+                        });
+                        let forward_output = original_output.and_then(|output| {
+                            match syn::parse2::<ModifiedType>(output) {
+                                Ok(ModifiedType { ty, modifiers }) => {
+                                    self.cef_name_map
+                                        .get(&ty.to_token_stream().to_string())
+                                        .map(|entry| match entry {
+                                            NameMapEntry {
+                                                ty: NameMapType::StructDeclaration(_),
+                                                ..
+                                            } => match modifiers.as_slice() {
+                                                [TypeModifier::ConstPtr] => {
+                                                    quote! { result.map(|result| result.into()).unwrap_or(std::ptr::null()) }
+                                                }
+                                                [TypeModifier::MutPtr] => {
+                                                    quote! { result.map(|result| result.into()).unwrap_or(std::ptr::null_mut()) }
+                                                }
+                                                _ => quote! { result.into() },
+                                            }
+                                            _ => quote! { result.into() },
+                                        })
+                                        .or_else(|| {
+                                            if unwrapped_args.is_empty() {
+                                                None
+                                            } else {
+                                                Some(quote! { result })
+                                            }
+                                        })
+                                }
+                                _ => None,
+                            }
+                        });
+                        let mut call_impl =
+                            quote! { #base_trait_ident::#rust_method_name(&arg_self_.interface, #(#forward_args),*) };
+                        if forward_output.is_some() || !unwrapped_args.is_empty() {
+                            call_impl = quote! { let result = #call_impl; };
+                        }
+
+                        quote! {
+                            extern "C" fn #name<I: #impl_trait>(#(#args),*) #output {
+                                #wrapped_args
+                                #call_impl
+                                #unwrapped_args
+                                #forward_output
+                            }
+                        }
+                    });
+
+                    let module_suffix = base_struct.name.trim_start_matches('_');
+                    let bridge_mod_ident = format_ident!("bridge_{}", module_suffix);
+                    quote! {
+                        pub(crate) mod #bridge_mod_ident {
+                            use super::*;
+                            pub fn init_methods<I: #impl_trait>(object: &mut #name_ident) {
+                                #(#init_methods)*
+                            }
+
+                            #(#wrapped_methods)*
+                        }
+                    }
+                })
+            })
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev();
+
         let base_ident = format_ident!("{BASE_REF_COUNTED}");
 
         let wrapper = quote! {
@@ -2565,7 +2960,7 @@ fn make_my_struct() -> {rust_name} {{
                 #(#impl_methods)*
 
                 fn init_methods(object: &mut #name_ident) {
-                    #(#init_bases)*
+                    #(#bridge_inits)*
                     #impl_mod::init_methods::<Self>(object);
                 }
 
@@ -2711,6 +3106,8 @@ fn make_my_struct() -> {rust_name} {{
                 }
 
                 #(#wrapped_methods)*
+
+                #(#bridge_modules)*
             }
 
             #(#impl_bases)*


### PR DESCRIPTION
I noticed that when implementing multiple interfaces for a type, the struct fields are all messed up

example:
```rust
wrap_window_delegate! {
  struct AppWindowDelegate {
    a: u32,
  }

  impl ViewDelegate {
    fn minimum_size(&self, view: Option<&mut View>) -> cef::Size {
      println!("min size {:?}", self.a);
      cef::Size { width: 0, height: 0 }
    }
  }

  impl PanelDelegate {}

  impl WindowDelegate {
    fn on_window_created(&self, window: Option<&mut Window>) {
      println!(" on window created {:?}", self.a);
      if let Some(window) = window {
        window.show();
      }
    }
  }
}
```
in this case, the WindowDelegate impl works fine, but the ViewDelegate impl does not get the proper `a` value. Looks like that's because the binding is missing a cast when calling a method from a "parent interface".