### PR TITLE
feat: support symlink for helper binaries

### DIFF
--- a/cef/src/library_loader.rs
+++ b/cef/src/library_loader.rs
@@ -9,12 +9,11 @@ impl LibraryLoader {
         "Chromium Embedded Framework.framework/Chromium Embedded Framework";
 
     pub fn new(path: &std::path::Path, helper: bool) -> Self {
-        let resolver = if helper {
-            "../../../.."
-        } else {
-            "../../Frameworks"
-        };
+        let resolver = if helper { "../../.." } else { "../Frameworks" };
         let path = path
+            // path is the current_exe path, read the parent to support symlinks
+            .parent()
+            .unwrap()
             .join(resolver)
             .join(Self::FRAMEWORK_PATH)
             .canonicalize()

--- a/cef/src/sandbox.rs
+++ b/cef/src/sandbox.rs
@@ -10,12 +10,15 @@ pub struct Sandbox {
 
 impl Sandbox {
     const LIBCEF_SANDBOX_PATH: &str =
-        "../../../../Chromium Embedded Framework.framework/Libraries/libcef_sandbox.dylib";
+        "../../../Chromium Embedded Framework.framework/Libraries/libcef_sandbox.dylib";
 
     pub fn new() -> Self {
         unsafe {
             let lib = Library::new(
                 std::env::current_exe()
+                    .unwrap()
+                    // use parent() so we the helper exe can be a symlink
+                    .parent()
                     .unwrap()
                     .join(Self::LIBCEF_SANDBOX_PATH)
                     .canonicalize()


### PR DESCRIPTION
we're canonicalizing the CEF framework path based on std::env::current_exe which might be a symlink; calling parent() first to resolve from the macOS folder makes the code support helper binaries that are symlinks to the main binary 