### PR TITLE
fix: use build-time OUT_DIR variable in get_cef_dir

### DIFF
--- a/sys/src/lib.rs
+++ b/sys/src/lib.rs
@@ -48,7 +48,7 @@ pub fn get_cef_dir() -> Option<PathBuf> {
             PathBuf::from(cef_path).canonicalize().ok()
         }
         Err(_) => {
-            let out_dir = PathBuf::from(env::var("OUT_DIR").ok()?);
+            let out_dir = PathBuf::from(env!("OUT_DIR"));
             let cef_dir = format!("cef_{OS}_{ARCH}");
             let cef_dir = out_dir.join(&cef_dir).canonicalize().ok()?;
             fs::exists(&cef_dir).ok()?.then_some(cef_dir)


### PR DESCRIPTION
I noticed while trying to reproduce #287 that `bundle_cefsimple` no longer works without the `CEF_PATH` environment variable. It looks like the `OUT_DIR` test in `get_cef_dir` used to run as part of the build script and checks the environment variable at runtime. It should be using the `OUT_DIR` environment variable from when the build script was run, but that's accessed with the `env!` macro instead of the `std::env::var` function.