### PR TITLE
fix: construct correct `extracted_dir`

### DIFF
--- a/download-cef/src/lib.rs
+++ b/download-cef/src/lib.rs
@@ -488,11 +488,17 @@ where
     let decoder = BzDecoder::new(BufReader::new(File::open(&archive)?));
     tar::Archive::new(decoder).unpack(&location)?;
 
-    let extracted_dir = archive.as_ref().display().to_string();
+    let extracted_dir = archive
+        .as_ref()
+        .file_name()
+        .unwrap() // Safe here due to File::open check above
+        .display()
+        .to_string();
     let extracted_dir = extracted_dir
         .strip_suffix(".tar.bz2")
         .map(PathBuf::from)
         .ok_or(Error::InvalidArchiveFile(extracted_dir))?;
+    let extracted_dir = location.as_ref().join(extracted_dir);
 
     let os_and_arch = OsAndArch::try_from(target)?;
     let OsAndArch { os, arch } = os_and_arch;


### PR DESCRIPTION
During my installation with `export-cef-dir`,

```bash
cargo run -p export-cef-dir -- --archive "../${file_name}" --force "${cef_dir}"
```
I ran into infinite "File not found OS Error".

And looked into the code,
https://github.com/tauri-apps/cef-rs/blob/bb5e07c74c1ed18f50f96f8a046b536f8e9db007/download-cef/src/lib.rs#L489
While the extracted_dir should be `location + archive_path.file_name .strip_suffix(".tar.bz2")`,
https://github.com/tauri-apps/cef-rs/blob/bb5e07c74c1ed18f50f96f8a046b536f8e9db007/download-cef/src/lib.rs#L491-L495
it was `archive_path .strip_suffix(".tar.bz2")` with neither filename extraction nor `location` aware.

