### PR TITLE
Add Win32_UI_WindowsAndMessaging feature to windows-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ x11-dl = "2"
 
 [workspace.dependencies.windows-sys]
 version = "0.61"
-features = ["Win32_System_Environment", "Win32_System_LibraryLoader"]
+features = ["Win32_System_Environment", "Win32_System_LibraryLoader", "Win32_UI_WindowsAndMessaging"]
 
 [workspace.dependencies.windows]
 version = "0.62"


### PR DESCRIPTION
the WindowsAndMessaging module is referenced but the feature flag is not enabled by the crate: https://github.com/tauri-apps/cef-rs/blob/da671f48a5b50afd5552cf0fd2bab5287243f18d/cef/src/window_info.rs#L3

the example enable it, that's why we do not see this issue: https://github.com/tauri-apps/cef-rs/blob/da671f48a5b50afd5552cf0fd2bab5287243f18d/examples/cefsimple/Cargo.toml#L50