### PR TITLE
feat: use fs_err instead of std::fs for better error logs

### DIFF
--- a/download-cef/CHANGELOG.md
+++ b/download-cef/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- use `fs_err` instead of `std::fs` for file operations
+
 ## [2.3.0](https://github.com/tauri-apps/cef-rs/compare/download-cef-v2.2.1...download-cef-v2.3.0) - 2026-01-01
 
 ### Added

--- a/download-cef/Cargo.toml
+++ b/download-cef/Cargo.toml
@@ -21,3 +21,4 @@ indicatif = "0.18"
 sha1_smol = "1"
 tar = "0.4"
 ureq = { version = "3", features = ["json", "socks-proxy"] }
+fs-err = "3.2.2"

--- a/download-cef/src/lib.rs
+++ b/download-cef/src/lib.rs
@@ -540,7 +540,7 @@ where
         cef_dir.join(LIBCEF_DLL_DIR),
     )?;
     const CREDITS_HTML: &str = "CREDITS.html";
-    fs::rename(extracted_dir.join(CREDITS_HTML), cef_dir.join(CREDITS_HTML))?;
+    fs_err::rename(extracted_dir.join(CREDITS_HTML), cef_dir.join(CREDITS_HTML))?;
 
     if show_progress {
         println!("Moved contents to: {}", cef_dir.display());

--- a/download-cef/src/lib.rs
+++ b/download-cef/src/lib.rs
@@ -2,11 +2,11 @@
 
 use bzip2::bufread::BzDecoder;
 use clap::ValueEnum;
+use fs_err::File;
 use regex::Regex;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use sha1_smol::Sha1;
-use fs_err::File;
 use std::{
     collections::HashMap,
     env,

--- a/download-cef/src/lib.rs
+++ b/download-cef/src/lib.rs
@@ -6,11 +6,11 @@ use regex::Regex;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use sha1_smol::Sha1;
+use fs_err::File;
 use std::{
     collections::HashMap,
     env,
     fmt::{self, Display},
-    fs::{self, File},
     io::{self, BufReader, IsTerminal, Write},
     path::{Path, PathBuf},
     sync::{Mutex, OnceLock},
@@ -252,7 +252,7 @@ impl CefVersion {
         let file = self.minimal()?;
         let (file, sha) = (file.name.as_str(), file.sha1.as_str());
 
-        fs::create_dir_all(&location)?;
+        fs_err::create_dir_all(&location)?;
         let download_file = location.as_ref().join(file);
 
         if download_file.exists() {
@@ -267,8 +267,8 @@ impl CefVersion {
                 println!("Cleaning corrupted archive: {}", download_file.display());
             }
             let corrupted_file = location.as_ref().join(format!("corrupted_{file}"));
-            fs::rename(&download_file, &corrupted_file)?;
-            fs::remove_file(&corrupted_file)?;
+            fs_err::rename(&download_file, &corrupted_file)?;
+            fs_err::remove_file(&corrupted_file)?;
         }
 
         let cef_url = format!("{url}/{file}");
@@ -485,7 +485,7 @@ where
     if show_progress {
         println!("Extracting archive: {}", archive.as_ref().display());
     }
-    let decoder = BzDecoder::new(BufReader::new(File::open(&archive)?));
+    let decoder = BzDecoder::new(BufReader::new(File::open(archive.as_ref())?));
     tar::Archive::new(decoder).unpack(&location)?;
 
     let extracted_dir = archive
@@ -510,32 +510,32 @@ where
         if show_progress {
             println!("Cleaning up: {}", old_dir.display());
         }
-        fs::rename(&cef_dir, &old_dir)?;
-        fs::remove_dir_all(old_dir)?;
+        fs_err::rename(&cef_dir, &old_dir)?;
+        fs_err::remove_dir_all(old_dir)?;
     }
     const RELEASE_DIR: &str = "Release";
-    fs::rename(extracted_dir.join(RELEASE_DIR), &cef_dir)?;
+    fs_err::rename(extracted_dir.join(RELEASE_DIR), &cef_dir)?;
 
     if os != "macos" {
         let resources = extracted_dir.join("Resources");
 
-        for entry in fs::read_dir(&resources)? {
+        for entry in fs_err::read_dir(&resources)? {
             let entry = entry?;
-            fs::rename(entry.path(), cef_dir.join(entry.file_name()))?;
+            fs_err::rename(entry.path(), cef_dir.join(entry.file_name()))?;
         }
     }
 
     const CMAKE_LISTS_TXT: &str = "CMakeLists.txt";
-    fs::rename(
+    fs_err::rename(
         extracted_dir.join(CMAKE_LISTS_TXT),
         cef_dir.join(CMAKE_LISTS_TXT),
     )?;
     const CMAKE_DIR: &str = "cmake";
-    fs::rename(extracted_dir.join(CMAKE_DIR), cef_dir.join(CMAKE_DIR))?;
+    fs_err::rename(extracted_dir.join(CMAKE_DIR), cef_dir.join(CMAKE_DIR))?;
     const INCLUDE_DIR: &str = "include";
-    fs::rename(extracted_dir.join(INCLUDE_DIR), cef_dir.join(INCLUDE_DIR))?;
+    fs_err::rename(extracted_dir.join(INCLUDE_DIR), cef_dir.join(INCLUDE_DIR))?;
     const LIBCEF_DLL_DIR: &str = "libcef_dll";
-    fs::rename(
+    fs_err::rename(
         extracted_dir.join(LIBCEF_DLL_DIR),
         cef_dir.join(LIBCEF_DLL_DIR),
     )?;
@@ -552,8 +552,8 @@ where
     if show_progress {
         println!("Cleaning up: {}", old_dir.display());
     }
-    fs::rename(&extracted_dir, &old_dir)?;
-    fs::remove_dir_all(old_dir)?;
+    fs_err::rename(&extracted_dir, &old_dir)?;
+    fs_err::remove_dir_all(old_dir)?;
 
     Ok(cef_dir)
 }


### PR DESCRIPTION
Subject says it all; as I could not build this crate correctly, I was debugging the installation process, and I found it's difficult as `std::fs` does not include information of path used, so I changed to use fs_err.

It would look like this:
```
  --- stdout
  cargo::rerun-if-changed=build.rs
  cargo::rerun-if-env-changed=FLATPAK
  cargo::rerun-if-env-changed=CEF_PATH

  --- stderr
  Error: File I/O error: failed to rename file from E:\aviutl2\vi5.aux2\target\debug\build\cef-dll-
sys-4755d3a1ffd215d0\out\cef_binary_143.0.14+gdd46a37+chromium-143.0.7499.193_windows64_minimal\inc
lude to E:\aviutl2\vi5.aux2\target\debug\build\cef-dll-sys-4755d3a1ffd215d0\out\cef_windows_x86_64\
include: アクセスが拒否されました。 (os error 5)

  Caused by:
      failed to rename file from E:\aviutl2\vi5.aux2\target\debug\build\cef-dll-sys-4755d3a1ffd215d
0\out\cef_binary_143.0.14+gdd46a37+chromium-143.0.7499.193_windows64_minimal\include to E:\aviutl2\
vi5.aux2\target\debug\build\cef-dll-sys-4755d3a1ffd215d0\out\cef_windows_x86_64\include: アクセスが
拒否されました。 (os error 5)
```