### PR TITLE
chore: check archive json instead of directory itself

### DIFF
--- a/sys/CHANGELOG.md
+++ b/sys/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- fix error during downloading and extracting CEF binaries causes invalid state
+
 ## [143.4.0+143.0.13](https://github.com/tauri-apps/cef-rs/compare/cef-dll-sys-v143.3.0+143.0.13...cef-dll-sys-v143.4.0+143.0.13) - 2025-12-30
 
 ### Added

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -26,7 +26,16 @@ fn main() -> anyhow::Result<()> {
             let cef_dir = os_arch.to_string();
             let cef_dir = out_dir.join(&cef_dir);
 
-            if !fs::exists(&cef_dir)? {
+            if download_cef::check_archive_json(
+                &env::var("CARGO_PKG_VERSION")?,
+                cef_dir.to_str().unwrap(),
+            )
+            .is_err()
+            {
+                if fs::exists(&cef_dir)? {
+                    // Remove incomplete or outdated CEF directory.
+                    fs::remove_dir_all(&cef_dir)?;
+                }
                 let cef_version = download_cef::default_version(&env::var("CARGO_PKG_VERSION")?);
                 let index = CefIndex::download()?;
                 let platform = index.platform(&target)?;


### PR DESCRIPTION
Subject says it all; as I could not build this crate correctly, I was debugging the installation process, and I found the `build.rs` treats incomplete state as completed.
