### PR TITLE
Support Unicode cmd line on Windows and fix metal object ref

### DIFF
--- a/cef/src/args.rs
+++ b/cef/src/args.rs
@@ -63,18 +63,11 @@ impl Args {
 
     #[cfg(target_os = "windows")]
     pub fn as_cmd_line(&self) -> Option<CommandLine> {
-        let cmd_line = command_line_create().and_then(|cmd_line| {
-            unsafe {
-                std::ffi::CStr::from_ptr(
-                    windows_sys::Win32::System::Environment::GetCommandLineA().cast(),
-                )
-            }
-            .to_str()
-            .ok()
-            .map(|args| {
-                cmd_line.init_from_string(Some(&CefString::from(args)));
-                cmd_line
-            })
+        command_line_create().map(|cmd_line| {
+            cmd_line.init_from_string(Some(&crate::CefString::from(
+                std::env::args().collect::<Vec<_>>().join(" ").as_str(),
+            )));
+            cmd_line
         });
         cmd_line
     }

--- a/cef/src/args.rs
+++ b/cef/src/args.rs
@@ -68,8 +68,7 @@ impl Args {
                 std::env::args().collect::<Vec<_>>().join(" ").as_str(),
             )));
             cmd_line
-        });
-        cmd_line
+        })
     }
 }
 

--- a/cef/src/osr_texture_import/iosurface.rs
+++ b/cef/src/osr_texture_import/iosurface.rs
@@ -127,39 +127,42 @@ impl IOSurfaceImporter {
         )?;
 
         let texture_desc = self.get_texture_desc();
-        let metal_desc = self.get_metal_desc(&texture_desc)?;
+        let hal_tex = objc::rc::autoreleasepool(|| {
+            let metal_desc = self.get_metal_desc(&texture_desc)?;
 
-        // Get Metal device from wgpu and create texture
-        let hal_tex = unsafe {
-            let hal_device_guard = device.as_hal::<wgpu::wgc::api::Metal>();
-            let Some(hal_device) = hal_device_guard else {
-                return Err(TextureImportError::InvalidHandle(
-                    "Failed to get Metal device from wgpu".to_string(),
-                ));
-            };
+            // Get Metal device from wgpu and create texture
+            let texture = unsafe {
+                let hal_device_guard = device.as_hal::<wgpu::wgc::api::Metal>();
+                let Some(hal_device) = hal_device_guard else {
+                    return Err(TextureImportError::InvalidHandle(
+                        "Failed to get Metal device from wgpu".to_string(),
+                    ));
+                };
 
-            let texture = objc::msg_send![
-                std::mem::transmute::<_,&metal::NSObject>(hal_device.raw_device()),
-                newTextureWithDescriptor:std::mem::transmute::<_,&metal::NSObject>(metal_desc.as_ref())
-                iosurface:io_surface
-                plane:0
-            ];
+                let texture = objc::msg_send![
+                    hal_device.raw_device().as_ref(),
+                    newTextureWithDescriptor:metal_desc.as_ref()
+                    iosurface:io_surface
+                    plane:0
+                ];
 
-            let hal_tex = <wgpu::wgc::api::Metal as wgpu::hal::Api>::Device::texture_from_raw(
-                texture,
-                texture_desc.format,
-                MTLTextureType::D2,
-                texture_desc.array_layer_count(),
-                texture_desc.mip_level_count,
-                wgpu::hal::CopyExtent {
-                    width: texture_desc.size.width,
-                    height: texture_desc.size.height,
-                    depth: texture_desc.array_layer_count(),
-                },
-            );
+                let hal_tex = <wgpu::wgc::api::Metal as wgpu::hal::Api>::Device::texture_from_raw(
+                    texture,
+                    texture_desc.format,
+                    MTLTextureType::D2,
+                    texture_desc.array_layer_count(),
+                    texture_desc.mip_level_count,
+                    wgpu::hal::CopyExtent {
+                        width: texture_desc.size.width,
+                        height: texture_desc.size.height,
+                        depth: texture_desc.array_layer_count(),
+                    },
+                );
 
-            Ok::<_, TextureImportError>(hal_tex)
-        }?;
+                Ok::<_, TextureImportError>(hal_tex)
+            }?;
+            Ok(texture)
+        })?;
 
         Ok(unsafe {
             device.create_texture_from_hal::<wgpu::wgc::api::Metal>(hal_tex, &texture_desc)


### PR DESCRIPTION
GetCommandLineA fails to handle unicode encoding

https://learn.microsoft.com/en-us/windows/win32/api/processenv/nf-processenv-getcommandlinea