### PR TITLE
fix: initialize CEF API version in cefsimple macOS helper

### DIFF
--- a/examples/cefsimple/src/bin/cefsimple_helper.rs
+++ b/examples/cefsimple/src/bin/cefsimple_helper.rs
@@ -17,6 +17,9 @@ fn main() {
         loader
     };
 
+    // Initialize the CEF API version.
+    let _ = api_hash(sys::CEF_API_VERSION_LAST, 0);
+
     execute_process(
         Some(args.as_main_args()),
         None::<&mut App>,


### PR DESCRIPTION
Hi,

I noticed that the `cefsimple_helper` example in cef-rs does not call `api_hash`, which is a required initialization step according to the CEF documentation. I therefore added `api_hash` step to `cefsimple_helper`.

Currently, when using CEF APIs such as `args.as_cmd_line()` on `cefsimple_helper`, cefsimple crashes. This patch brings the cef-rs cefsimple macOS helper in line with the official CEF C API behavior.

References:
- https://chromiumembedded.github.io/cef/using_the_capi#api-version-initialization
- https://github.com/chromiumembedded/cef/blob/5f93c2b090d19659451de4dfe44896ad7dbfd832/tests/cefsimple_capi/cefsimple_mac.m#L105-L107