### PR TITLE
fix: resolve several issues in message router

### DIFF
--- a/cef/CHANGELOG.md
+++ b/cef/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- port missing early returns in BrowserSideRouter and BrowserInfoMap to prevent panics during startup
+- return string responses as V8 strings instead of ArrayBuffer from RendererSideRouter
+
 ## [144.0.1+144.0.6](https://github.com/tauri-apps/cef-rs/compare/cef-v144.0.0+144.0.6...cef-v144.0.1+144.0.6) - 2026-01-22
 
 ### Other

--- a/cef/src/wrapper/browser_info_map.rs
+++ b/cef/src/wrapper/browser_info_map.rs
@@ -107,10 +107,13 @@ impl<K: Copy + Ord, V: Clone> BrowserInfoMap<K, V> {
     /// Find all objects associated with the specified browser. If any objects are
     /// removed using the Visitor the caller is responsible for destroying them.
     pub fn find_browser_all(&mut self, browser_id: i32, visitor: &dyn BrowserInfoMapVisitor<K, V>) {
-        let info_map = self
-            .map
-            .get_mut(&browser_id)
-            .expect("missing browser info map");
+        if self.map.is_empty() {
+            return;
+        }
+
+        let Some(info_map) = self.map.get_mut(&browser_id) else {
+            return;
+        };
 
         let mut removed = vec![];
         let keys: Vec<_> = info_map.keys().copied().collect();

--- a/cef/src/wrapper/message_router.rs
+++ b/cef/src/wrapper/message_router.rs
@@ -666,6 +666,10 @@ impl BrowserSideRouter {
             return;
         };
 
+        if browser_query_info_map.is_empty() {
+            return;
+        }
+
         struct Visitor {
             router: Arc<BrowserSideRouter>,
             handler_id: Option<HandlerId>,

--- a/cef/src/wrapper/message_router.rs
+++ b/cef/src/wrapper/message_router.rs
@@ -1326,28 +1326,35 @@ impl RendererSideRouter {
         let Some(mut context) = self.get_context_by_id(context_id) else {
             return;
         };
-        if context.enter() == 0 {
-            return;
-        }
 
-        let data = match &response {
-            mru::MessagePayload::Empty => &[],
-            mru::MessagePayload::String(s) => s.as_slice().unwrap_or(&[]),
-            mru::MessagePayload::Binary(b) => b.data(),
+        let value = match &response {
+            mru::MessagePayload::String(s) => v8_value_create_string(Some(&s.into())),
+            mru::MessagePayload::Empty | mru::MessagePayload::Binary(_) => {
+                let data = match &response {
+                    mru::MessagePayload::Binary(b) => b.data(),
+                    _ => &[],
+                };
+
+                if context.enter() == 0 {
+                    return;
+                }
+
+                #[cfg(feature = "sandbox")]
+                let value =
+                    v8_value_create_array_buffer_with_copy(data.as_ptr() as *mut u8, data.len());
+                #[cfg(not(feature = "sandbox"))]
+                let value = v8_value_create_array_buffer(
+                    data.as_ptr() as *mut u8,
+                    data.len(),
+                    Some(&mut mru::BinaryValueArrayBufferReleaseCallback::new(
+                        response,
+                    )),
+                );
+
+                context.exit();
+                value
+            }
         };
-
-        #[cfg(feature = "sandbox")]
-        let value = v8_value_create_array_buffer_with_copy(data.as_ptr() as *mut u8, data.len());
-        #[cfg(not(feature = "sandbox"))]
-        let value = v8_value_create_array_buffer(
-            data.as_ptr() as *mut u8,
-            data.len(),
-            Some(&mut mru::BinaryValueArrayBufferReleaseCallback::new(
-                response,
-            )),
-        );
-
-        context.exit();
 
         success_callback.execute_function_with_context(Some(&mut context), None, Some(&[value]));
     }


### PR DESCRIPTION
#### Summary

This Pull Request addresses critical issues in the Message Router component to align its behavior with the original CEF C++ implementation. These fixes prevent application panics during startup and ensure correct data type mapping for IPC responses.

#### Linked Issues

-   Closes #346 (Panic in BrowserInfoMap)
-   Closes #347 (Incorrect response type in RendererSideRouter)

#### Changes

1.  **Added missing early returns in `BrowserSideRouter` and `BrowserInfoMap`**
    -   Implemented checks to return early if the browser is not yet registered or the map is empty.
    -   This prevents a panic with `.expect("missing browser info map")` when navigation occurs before the router is fully initialized.
    -   **Reference**: [cef_browser_info_map.h#L159-L167](https://github.com/chromiumembedded/cef/blob/5f93c2b090d19659451de4dfe44896ad7dbfd832/libcef_dll/wrapper/cef_browser_info_map.h#L159-L167), [cef_message_router.cc#L535-537](https://github.com/chromiumembedded/cef/blob/5f93c2b090d19659451de4dfe44896ad7dbfd832/libcef_dll/wrapper/cef_message_router.cc#L535-L537)

2.  **Fixed response type mapping in `RendererSideRouter`**
    -   Updated `execute_success_callback` to return `MessagePayload::String` as a V8 string instead of an `ArrayBuffer`.
    -   This ensures JavaScript's `onSuccess` callback receives a proper string, matching standard CEF behavior.
    -   **Reference**: [cef_message_router.cc#L1034-L1057](https://github.com/chromiumembedded/cef/blob/5f93c2b090d19659451de4dfe44896ad7dbfd832/libcef_dll/wrapper/cef_message_router.cc#L1034-L1058)

#### Verification

Verified using a port of the official CEF [`message_router` example](https://github.com/chromiumembedded/cef-project/tree/master/examples/message_router): [tasuren/cef-rs-message-router](https://github.com/tasuren/cef-rs-message-router)

-   **Before**: The application panics on startup, or (if forced to run) returns `[object ArrayBuffer]` to JavaScript.
-   **After**: The application initializes correctly and JavaScript receives string responses as expected.