### PR TITLE
fix: filter undefined values for optional cefQuery persistent field

### DIFF
--- a/cef/CHANGELOG.md
+++ b/cef/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Filter undefined values for optional cefQuery persistent field
+
 ## [144.0.1+144.0.6](https://github.com/tauri-apps/cef-rs/compare/cef-v144.0.0+144.0.6...cef-v144.0.1+144.0.6) - 2026-01-22
 
 ### Other

--- a/cef/src/wrapper/message_router.rs
+++ b/cef/src/wrapper/message_router.rs
@@ -1691,7 +1691,7 @@ wrap_v8_handler! {
                 };
 
                 let key = CefString::from(ObjectMember::PERSISTENT);
-                let persistent = if let Some(persistent) = arg.value_bykey(Some(&key)) {
+                let persistent = if let Some(persistent) = arg.value_bykey(Some(&key)).filter(|v| v.is_undefined() == 0) {
                     if persistent.is_bool() == 0 {
                         return_exception!(format!(
                             "Invalid arguments; object member '{}' must have type boolean",


### PR DESCRIPTION
## Summary

Filter out `undefined` V8 values returned by `value_bykey` for missing object keys, so the optional `persistent` field in `cefQuery` is correctly treated as absent.

Closes #354 

## Problem

`value_bykey` wraps CEF's `GetValue` C API, which returns a non-null `undefined` V8 value for missing keys. The Rust binding only null-checks the pointer, so it returns `Some(v8_undefined)` instead of `None`. This causes the optional `persistent` field check to enter the type-validation branch, where `is_bool()` fails on `undefined` and `return_exception!` silently aborts the query -- no callback fires, no error is thrown.

## Fix

Add `.filter(|v| v.is_undefined() == 0)` to the `value_bykey` call so that `undefined` values are mapped to `None`, matching the [CEF C++ reference implementation](https://bitbucket.org/chromiumembedded/cef/src/master/libcef_dll/wrapper/cef_message_router.cc) which checks `IsUndefined()` for optional fields.

## Verification

Tested with a [message router example app](https://github.com/jdboyer/cef-rs/tree/repro/persistent-field-bug/examples/message_router) that calls `cefQuery` with and without the `persistent` field. Before the fix, omitting `persistent` silently drops the query. After the fix, both calls receive the expected `SUCCESS` callback.
