### PR TITLE
Include CREDITS.html in extracted cef dir

### DIFF
--- a/download-cef/src/lib.rs
+++ b/download-cef/src/lib.rs
@@ -539,6 +539,8 @@ where
         extracted_dir.join(LIBCEF_DLL_DIR),
         cef_dir.join(LIBCEF_DLL_DIR),
     )?;
+    const CREDITS_HTML: &str = "CREDITS.html";
+    fs::rename(extracted_dir.join(CREDITS_HTML), cef_dir.join(CREDITS_HTML))?;
 
     if show_progress {
         println!("Moved contents to: {}", cef_dir.display());


### PR DESCRIPTION
This matters for downstream consumers that need to include third-party attributions. For example, we include this file in our third-party-licenses.txt in Graphite.