### PR TITLE
[WIP] gpu-backend: dawn

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,8 @@ tracing = "0.1"
 wgpu = "28"
 winres = "0.1"
 x11-dl = "2"
+dawn-rs = { git = "https://github.com/csmoe/dawn-rs", "branch" = "wire" }
+dawn-wgpu = { git = "https://github.com/csmoe/dawn-rs", "branch" = "wire" }
 
 [workspace.dependencies.windows-sys]
 version = "0.61"

--- a/cef/Cargo.toml
+++ b/cef/Cargo.toml
@@ -30,6 +30,7 @@ accelerated_osr = [
     "wgpu",
     "windows",
 ]
+accelerated_osr_dawn = ["accelerated_osr", "dep:dawn-rs", "dep:dawn-wgpu"]
 
 # Build utilities, including the bundle-cef-app tool.
 build-util = [
@@ -57,6 +58,8 @@ ash = { workspace = true, optional = true }
 thiserror = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
 wgpu = { workspace = true, optional = true }
+dawn-rs = { workspace = true, optional = true }
+dawn-wgpu = { workspace = true, optional = true }
 
 # bundle
 anyhow = { workspace = true, optional = true }

--- a/cef/src/osr_texture_import/common.rs
+++ b/cef/src/osr_texture_import/common.rs
@@ -19,6 +19,17 @@ pub mod format {
         }
     }
 
+    #[cfg(feature = "accelerated_osr_dawn")]
+    pub fn cef_to_dawn(
+        format: cef_color_type_t,
+    ) -> Result<dawn_rs::TextureFormat, TextureImportError> {
+        match format {
+            cef_color_type_t::CEF_COLOR_TYPE_BGRA_8888 => Ok(dawn_rs::TextureFormat::Bgra8Unorm),
+            cef_color_type_t::CEF_COLOR_TYPE_RGBA_8888 => Ok(dawn_rs::TextureFormat::Rgba8Unorm),
+            _ => Err(TextureImportError::UnsupportedFormat { format }),
+        }
+    }
+
     #[cfg(target_os = "linux")]
     /// Convert CEF color type to Vulkan format
     pub fn cef_to_vulkan(format: cef_color_type_t) -> Result<ash::vk::Format, TextureImportError> {

--- a/cef/src/osr_texture_import/d3d11.rs
+++ b/cef/src/osr_texture_import/d3d11.rs
@@ -26,6 +26,19 @@ impl TextureImporter for D3D11Importer {
     fn import_to_wgpu(&self, device: &wgpu::Device) -> TextureImportResult {
         // Try hardware acceleration first
         if self.supports_hardware_acceleration(device) {
+            #[cfg(feature = "accelerated_osr_dawn")]
+            match self.import_via_dawn(device) {
+                Ok(texture) => {
+                    tracing::info!("Successfully imported D3D11 shared texture via Dawn");
+                    return Ok(texture);
+                }
+                Err(e) => {
+                    tracing::debug!(
+                        "Failed to import D3D11 via Dawn: {}, trying native fallback",
+                        e
+                    );
+                }
+            }
             // Try D3D12 first (most efficient on Windows)
             if vulkan::is_d3d12_backend(device) {
                 match self.import_via_d3d12(device) {
@@ -75,12 +88,98 @@ impl TextureImporter for D3D11Importer {
             return false;
         }
 
+        #[cfg(feature = "accelerated_osr_dawn")]
+        if dawn_wgpu::Compat::<dawn_rs::Device>::try_from(device).is_ok() {
+            return true;
+        }
+
         // Check if wgpu is using D3D12 or Vulkan backend
         vulkan::is_d3d12_backend(device) || vulkan::is_vulkan_backend(device)
     }
 }
 
 impl D3D11Importer {
+    #[cfg(feature = "accelerated_osr_dawn")]
+    fn import_via_dawn(&self, device: &wgpu::Device) -> TextureImportResult {
+        use dawn_wgpu::{Compat, CompatTexture};
+
+        let dawn_device = Compat::<dawn_rs::Device>::try_from(device)
+            .map_err(|_| TextureImportError::HardwareUnavailable {
+                reason: "wgpu device is not backed by dawn-wgpu".into(),
+            })?
+            .into_inner();
+        if !dawn_device.has_feature(dawn_rs::FeatureName::SharedTextureMemoryDXGISharedHandle) {
+            return Err(TextureImportError::HardwareUnavailable {
+                reason: "SharedTextureMemoryDXGISharedHandle feature is unavailable".into(),
+            });
+        }
+
+        let mut dxgi_desc = dawn_rs::SharedTextureMemoryDXGISharedHandleDescriptor::new();
+        dxgi_desc.handle = Some(self.handle);
+        dxgi_desc.use_keyed_mutex = Some(false);
+        let shared_desc =
+            dawn_rs::SharedTextureMemoryDescriptor::new().with_extension(dxgi_desc.into());
+        let shared_memory = dawn_device.import_shared_texture_memory(&shared_desc);
+
+        let mut properties = dawn_rs::SharedTextureMemoryProperties::new();
+        let properties_status = shared_memory.get_properties(&mut properties);
+        if properties_status != dawn_rs::Status::Success {
+            return Err(TextureImportError::PlatformError {
+                message: format!(
+                    "Dawn DXGI get_properties failed with {:?}",
+                    properties_status
+                ),
+            });
+        }
+
+        let mut dawn_texture_desc = dawn_rs::TextureDescriptor::new();
+        dawn_texture_desc.dimension = Some(dawn_rs::TextureDimension::D2);
+        dawn_texture_desc.format = properties
+            .format
+            .or(Some(format::cef_to_dawn(self.format)?));
+        let usage = properties
+            .usage
+            .unwrap_or(dawn_rs::TextureUsage::TEXTURE_BINDING)
+            | dawn_rs::TextureUsage::TEXTURE_BINDING;
+        dawn_texture_desc.usage = Some(usage);
+        dawn_texture_desc.size = properties.size.or(Some(dawn_rs::Extent3D {
+            width: Some(self.width),
+            height: Some(self.height),
+            depth_or_array_layers: Some(1),
+        }));
+
+        let dawn_texture = shared_memory.create_texture(Some(&dawn_texture_desc));
+        let mut begin_desc = dawn_rs::SharedTextureMemoryBeginAccessDescriptor::new();
+        begin_desc.initialized = Some(true);
+        begin_desc.concurrent_read = Some(false);
+        let status = shared_memory.begin_access(dawn_texture.clone(), &begin_desc);
+        if status != dawn_rs::Status::Success {
+            return Err(TextureImportError::PlatformError {
+                message: format!("Dawn DXGI begin_access failed with {:?}", status),
+            });
+        }
+
+        let texture_desc = wgpu::TextureDescriptor {
+            label: Some("CEF Dawn DXGI Texture"),
+            size: wgpu::Extent3d {
+                width: self.width,
+                height: self.height,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: format::cef_to_wgpu(self.format)?,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING,
+            view_formats: &[],
+        };
+        let texture = wgpu::Texture::from(CompatTexture::new(dawn_texture.clone(), &texture_desc));
+
+        let _ = shared_memory;
+
+        Ok(texture)
+    }
+
     fn import_via_d3d12(&self, device: &wgpu::Device) -> TextureImportResult {
         // Get wgpu's D3D12 device
         use wgpu::hal::api;

--- a/cef/src/osr_texture_import/dmabuf.rs
+++ b/cef/src/osr_texture_import/dmabuf.rs
@@ -32,6 +32,19 @@ impl TextureImporter for DmaBufImporter {
     fn import_to_wgpu(&self, device: &wgpu::Device) -> TextureImportResult {
         // Try hardware acceleration first
         if self.supports_hardware_acceleration(device) {
+            #[cfg(feature = "accelerated_osr_dawn")]
+            match self.import_via_dawn(device) {
+                Ok(texture) => {
+                    tracing::info!("Successfully imported DMA-BUF texture via Dawn");
+                    return Ok(texture);
+                }
+                Err(e) => {
+                    tracing::debug!(
+                        "Failed to import DMA-BUF via Dawn: {}, trying Vulkan fallback",
+                        e
+                    );
+                }
+            }
             match self.import_via_vulkan(device) {
                 Ok(texture) => {
                     tracing::info!("Successfully imported DMA-BUF texture via Vulkan");
@@ -74,12 +87,134 @@ impl TextureImporter for DmaBufImporter {
             }
         }
 
+        #[cfg(feature = "accelerated_osr_dawn")]
+        if dawn_wgpu::Compat::<dawn_rs::Device>::try_from(device).is_ok() {
+            return true;
+        }
+
         // Check if wgpu is using Vulkan backend
         vulkan::is_vulkan_backend(device)
     }
 }
 
 impl DmaBufImporter {
+    #[cfg(feature = "accelerated_osr_dawn")]
+    fn drm_fourcc_from_cef(&self) -> Result<u32, TextureImportError> {
+        const fn fourcc(a: u8, b: u8, c: u8, d: u8) -> u32 {
+            (a as u32) | ((b as u32) << 8) | ((c as u32) << 16) | ((d as u32) << 24)
+        }
+        match self.format {
+            // BGRA in memory usually maps to DRM AR24
+            cef_color_type_t::CEF_COLOR_TYPE_BGRA_8888 => Ok(fourcc(b'A', b'R', b'2', b'4')),
+            // RGBA in memory usually maps to DRM AB24
+            cef_color_type_t::CEF_COLOR_TYPE_RGBA_8888 => Ok(fourcc(b'A', b'B', b'2', b'4')),
+            _ => Err(TextureImportError::UnsupportedFormat {
+                format: self.format,
+            }),
+        }
+    }
+
+    #[cfg(feature = "accelerated_osr_dawn")]
+    fn import_via_dawn(&self, device: &wgpu::Device) -> TextureImportResult {
+        use dawn_wgpu::{Compat, CompatTexture};
+
+        let dawn_device = Compat::<dawn_rs::Device>::try_from(device)
+            .map_err(|_| TextureImportError::HardwareUnavailable {
+                reason: "wgpu device is not backed by dawn-wgpu".into(),
+            })?
+            .into_inner();
+        if !dawn_device.has_feature(dawn_rs::FeatureName::SharedTextureMemoryDmaBuf) {
+            return Err(TextureImportError::HardwareUnavailable {
+                reason: "SharedTextureMemoryDmaBuf feature is unavailable".into(),
+            });
+        }
+
+        let mut planes = Vec::with_capacity(self.fds.len());
+        for i in 0..self.fds.len() {
+            let dup_fd = unsafe { libc::dup(self.fds[i]) };
+            if dup_fd < 0 {
+                return Err(TextureImportError::PlatformError {
+                    message: "Failed to dup DMA-BUF file descriptor".into(),
+                });
+            }
+            let mut plane = dawn_rs::SharedTextureMemoryDmaBufPlane::new();
+            plane.fd = Some(dup_fd);
+            plane.offset = Some(self.offsets.get(i).copied().unwrap_or(0) as u64);
+            plane.stride = Some(self.strides.get(i).copied().unwrap_or(0));
+            planes.push(plane);
+        }
+
+        let mut desc = dawn_rs::SharedTextureMemoryDmaBufDescriptor::new();
+        desc.size = Some(dawn_rs::Extent3D {
+            width: Some(self.width),
+            height: Some(self.height),
+            depth_or_array_layers: Some(1),
+        });
+        desc.drm_format = Some(self.drm_fourcc_from_cef()?);
+        desc.drm_modifier = Some(self.modifier);
+        desc.planes = Some(planes);
+        let shared_desc = dawn_rs::SharedTextureMemoryDescriptor::new().with_extension(desc.into());
+        let shared_memory = dawn_device.import_shared_texture_memory(&shared_desc);
+
+        let mut properties = dawn_rs::SharedTextureMemoryProperties::new();
+        let properties_status = shared_memory.get_properties(&mut properties);
+        if properties_status != dawn_rs::Status::Success {
+            return Err(TextureImportError::PlatformError {
+                message: format!(
+                    "Dawn DMA-BUF get_properties failed with {:?}",
+                    properties_status
+                ),
+            });
+        }
+
+        let mut dawn_texture_desc = dawn_rs::TextureDescriptor::new();
+        dawn_texture_desc.dimension = Some(dawn_rs::TextureDimension::D2);
+        dawn_texture_desc.format = properties
+            .format
+            .or(Some(format::cef_to_dawn(self.format)?));
+        let usage = properties
+            .usage
+            .unwrap_or(dawn_rs::TextureUsage::TEXTURE_BINDING)
+            | dawn_rs::TextureUsage::TEXTURE_BINDING;
+        dawn_texture_desc.usage = Some(usage);
+        dawn_texture_desc.size = properties.size.or(Some(dawn_rs::Extent3D {
+            width: Some(self.width),
+            height: Some(self.height),
+            depth_or_array_layers: Some(1),
+        }));
+
+        let dawn_texture = shared_memory.create_texture(Some(&dawn_texture_desc));
+        let mut begin_desc = dawn_rs::SharedTextureMemoryBeginAccessDescriptor::new();
+        begin_desc.initialized = Some(true);
+        begin_desc.concurrent_read = Some(false);
+        let status = shared_memory.begin_access(dawn_texture.clone(), &begin_desc);
+        if status != dawn_rs::Status::Success {
+            return Err(TextureImportError::PlatformError {
+                message: format!("Dawn DMA-BUF begin_access failed with {:?}", status),
+            });
+        }
+
+        let texture_desc = wgpu::TextureDescriptor {
+            label: Some("CEF Dawn DMA-BUF Texture"),
+            size: wgpu::Extent3d {
+                width: self.width,
+                height: self.height,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: format::cef_to_wgpu(self.format)?,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING,
+            view_formats: &[],
+        };
+        let texture = wgpu::Texture::from(CompatTexture::new(dawn_texture.clone(), &texture_desc));
+
+        let _ = shared_memory;
+
+        Ok(texture)
+    }
+
     fn import_via_vulkan(&self, device: &wgpu::Device) -> TextureImportResult {
         // Get wgpu's Vulkan instance and device
         use wgpu::{wgc::api::Vulkan, TextureUses};

--- a/cef/src/osr_texture_import/iosurface.rs
+++ b/cef/src/osr_texture_import/iosurface.rs
@@ -34,6 +34,16 @@ impl TextureImporter for IOSurfaceImporter {
     fn import_to_wgpu(&self, device: &wgpu::Device) -> TextureImportResult {
         // Try hardware acceleration first
         if self.supports_hardware_acceleration(device) {
+            #[cfg(feature = "accelerated_osr_dawn")]
+            match self.import_via_dawn(device) {
+                Ok(texture) => {
+                    tracing::trace!("Successfully imported IOSurface texture via Dawn");
+                    return Ok(texture);
+                }
+                Err(e) => {
+                    tracing::debug!("Failed to import IOSurface via Dawn: {}", e);
+                }
+            }
             match self.import_via_metal(device) {
                 Ok(texture) => {
                     tracing::trace!("Successfully imported IOSurface texture via Metal");
@@ -64,12 +74,101 @@ impl TextureImporter for IOSurfaceImporter {
             return false;
         }
 
+        #[cfg(feature = "accelerated_osr_dawn")]
+        if dawn_wgpu::Compat::<dawn_rs::Device>::try_from(device).is_ok() {
+            return true;
+        }
+
         // Check if wgpu is using Metal backend
         self.is_metal_backend(device)
     }
 }
 
 impl IOSurfaceImporter {
+    #[cfg(feature = "accelerated_osr_dawn")]
+    fn cef_to_dawn(format: cef_color_type_t) -> dawn_rs::TextureFormat {
+        match format {
+            cef_color_type_t::CEF_COLOR_TYPE_RGBA_8888 => dawn_rs::TextureFormat::Rgba8Unorm,
+            _ => dawn_rs::TextureFormat::Bgra8Unorm,
+        }
+    }
+
+    #[cfg(feature = "accelerated_osr_dawn")]
+    fn import_via_dawn(&self, device: &wgpu::Device) -> TextureImportResult {
+        use dawn_wgpu::{Compat, CompatTexture};
+
+        if self.handle.is_null() {
+            return Err(TextureImportError::InvalidHandle(
+                "Invalid IOSurface handle".to_string(),
+            ));
+        }
+
+        let dawn_device = Compat::<dawn_rs::Device>::try_from(device)
+            .map_err(|_| TextureImportError::HardwareUnavailable {
+                reason: "wgpu device is not backed by dawn-wgpu".into(),
+            })?
+            .into_inner();
+        if !dawn_device.has_feature(dawn_rs::FeatureName::SharedTextureMemoryIOSurface) {
+            return Err(TextureImportError::HardwareUnavailable {
+                reason: "SharedTextureMemoryIOSurface feature is unavailable".into(),
+            });
+        }
+
+        let mut iosurface_desc = dawn_rs::SharedTextureMemoryIOSurfaceDescriptor::new();
+        iosurface_desc.io_surface = Some(self.handle.cast());
+        iosurface_desc.allow_storage_binding = Some(false);
+        let shared_desc =
+            dawn_rs::SharedTextureMemoryDescriptor::new().with_extension(iosurface_desc.into());
+        let shared_memory = dawn_device.import_shared_texture_memory(&shared_desc);
+
+        let mut properties = dawn_rs::SharedTextureMemoryProperties::new();
+        let properties_status = shared_memory.get_properties(&mut properties);
+        if properties_status != dawn_rs::Status::Success {
+            return Err(TextureImportError::PlatformError {
+                message: format!(
+                    "Dawn IOSurface get_properties failed with {:?}",
+                    properties_status
+                ),
+            });
+        }
+
+        let mut dawn_texture_desc = dawn_rs::TextureDescriptor::new();
+        dawn_texture_desc.dimension = Some(dawn_rs::TextureDimension::D2);
+        dawn_texture_desc.format = properties.format.or(Some(Self::cef_to_dawn(self.format)));
+        let usage = properties
+            .usage
+            .unwrap_or(dawn_rs::TextureUsage::TEXTURE_BINDING)
+            | dawn_rs::TextureUsage::TEXTURE_BINDING;
+        dawn_texture_desc.usage = Some(usage);
+        dawn_texture_desc.size = properties.size.or(Some(dawn_rs::Extent3D {
+            width: Some(self.width),
+            height: Some(self.height),
+            depth_or_array_layers: Some(1),
+        }));
+
+        let dawn_texture = shared_memory.create_texture(Some(&dawn_texture_desc));
+
+        let mut begin_desc = dawn_rs::SharedTextureMemoryBeginAccessDescriptor::new();
+        begin_desc.initialized = Some(true);
+        begin_desc.concurrent_read = Some(false);
+        let status = shared_memory.begin_access(dawn_texture.clone(), &begin_desc);
+        if status != dawn_rs::Status::Success {
+            return Err(TextureImportError::PlatformError {
+                message: format!(
+                    "Dawn IOSurface begin_access failed with {:?} (initialized=true, concurrent_read=false)",
+                    status
+                ),
+            });
+        }
+
+        let texture_desc = self.get_texture_desc();
+        let texture = wgpu::Texture::from(CompatTexture::new(dawn_texture.clone(), &texture_desc));
+
+        let _ = shared_memory;
+
+        Ok(texture)
+    }
+
     fn get_texture_desc(&self) -> TextureDescriptor<'_> {
         use wgpu::{Extent3d, TextureDimension, TextureUsages};
 

--- a/cef/src/osr_texture_import/mod.rs
+++ b/cef/src/osr_texture_import/mod.rs
@@ -50,6 +50,7 @@
 //! - `accelerated_paint_dmabuf` - Linux DMA-BUF support
 //! - `accelerated_paint_d3d11` - Windows D3D11 support
 //! - `accelerated_paint_iosurface` - macOS IOSurface support
+//! - `accelerated_osr_dawn` - Dawn-based shared texture import on macOS
 
 pub(crate) mod common;
 

--- a/examples/osr_dawn/Cargo.toml
+++ b/examples/osr_dawn/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "cef-osr-dawn"
+edition = "2024"
+publish = false
+
+[features]
+default = ["accelerated_osr"]
+accelerated_osr = ["cef/accelerated_osr", "cef/accelerated_osr_dawn"]
+
+[package.metadata.cef.bundle]
+helper_name = "cefsimple_helper"
+
+[dependencies]
+cef.workspace = true
+wgpu.workspace = true
+dawn-rs.workspace = true
+dawn-wgpu.workspace = true
+
+env_logger = "0.11"
+pollster = "0.4"
+tokio = { version = "1", features = ["full"] }
+winit = { version = "0.30" }
+bytemuck = "1"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = { workspace = true }
+# For gpu debugging on Windows with PIX
+libloading.workspace = true
+
+[target.'cfg(target_os = "macos")'.dependencies]
+metal.workspace = true
+objc.workspace = true
+io-surface.workspace = true
+
+[target.'cfg(target_os = "linux")'.dependencies]
+libc.workspace = true

--- a/examples/osr_dawn/src/main.rs
+++ b/examples/osr_dawn/src/main.rs
@@ -1,0 +1,572 @@
+mod webrender;
+
+use cef::{args::Args, *};
+use dawn_rs::Instance as DawnInstance;
+use dawn_wgpu::Compat;
+use std::{cell::RefCell, process::ExitCode, sync::Arc, thread::sleep, time::Duration};
+use wgpu::util::DeviceExt;
+use winit::{
+    application::ApplicationHandler,
+    event::WindowEvent,
+    event_loop::{ActiveEventLoop, ControlFlow, EventLoop},
+    platform::pump_events::{EventLoopExtPumpEvents, PumpStatus},
+    window::{Window, WindowAttributes, WindowId},
+};
+
+use crate::webrender::{
+    ClientBuilder, OsrApp, OsrRenderHandler, OsrRequestContextHandler,
+    RequestContextHandlerBuilder, texture_slot,
+};
+
+struct State {
+    window: Arc<Window>,
+    device: wgpu::Device,
+    pipeline: wgpu::RenderPipeline,
+    queue: wgpu::Queue,
+    size: winit::dpi::PhysicalSize<u32>,
+    surface: wgpu::Surface<'static>,
+    surface_format: wgpu::TextureFormat,
+    quad: Geometry,
+}
+
+impl State {
+    async fn new(window: Arc<Window>) -> State {
+        let dawn_instance = DawnInstance::new(None);
+        let instance: wgpu::Instance = Compat::from(dawn_instance).into();
+        let adapter = instance
+            .request_adapter(&wgpu::RequestAdapterOptions {
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        let (device, queue) =
+            if let Ok(dawn_adapter) = dawn_wgpu::Compat::<dawn_rs::Adapter>::try_from(&adapter) {
+                let dawn_adapter = dawn_adapter.into_inner();
+                let mut device_desc = dawn_rs::DeviceDescriptor::new();
+                let mut required_features = Vec::new();
+                #[cfg(target_os = "macos")]
+                required_features.push(dawn_rs::FeatureName::SharedTextureMemoryIOSurface);
+                #[cfg(target_os = "linux")]
+                required_features.push(dawn_rs::FeatureName::SharedTextureMemoryDmaBuf);
+                #[cfg(target_os = "windows")]
+                required_features.push(dawn_rs::FeatureName::SharedTextureMemoryDXGISharedHandle);
+                if !required_features.is_empty() {
+                    device_desc.required_features = Some(required_features);
+                }
+                let error_info = dawn_rs::UncapturedErrorCallbackInfo::new();
+                error_info.callback.replace(Some(Box::new(|_, ty, message| {
+                    eprintln!("dawn uncaptured error {:?}: {}", ty, message);
+                })));
+                device_desc.uncaptured_error_callback_info = Some(error_info);
+                let dawn_device = dawn_adapter.create_device(Some(&device_desc));
+                let dawn_queue = dawn_device.get_queue();
+                (
+                    <wgpu::Device as From<dawn_wgpu::Compat<dawn_rs::Device>>>::from(
+                        dawn_wgpu::Compat::from(dawn_device),
+                    ),
+                    <wgpu::Queue as From<dawn_wgpu::Compat<dawn_rs::Queue>>>::from(
+                        dawn_wgpu::Compat::from(dawn_queue),
+                    ),
+                )
+            } else {
+                adapter
+                    .request_device(&wgpu::DeviceDescriptor {
+                        required_limits: wgpu::Limits::default(),
+                        ..Default::default()
+                    })
+                    .await
+                    .unwrap()
+            };
+
+        let size = window.inner_size();
+
+        let surface = unsafe {
+            let target = wgpu::SurfaceTargetUnsafe::from_window(window.as_ref()).unwrap();
+            instance.create_surface_unsafe(target).unwrap()
+        };
+        let surface_format = wgpu::TextureFormat::Bgra8Unorm;
+        let texture_bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("Cef Texture Bind Group Layout"),
+                entries: &[
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Texture {
+                            multisampled: false,
+                            view_dimension: wgpu::TextureViewDimension::D2,
+                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        },
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 1,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                        count: None,
+                    },
+                ],
+            });
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("Cef Shader"),
+            source: wgpu::ShaderSource::Wgsl(include_str!("shader.wgsl").into()),
+        });
+
+        let render_pipeline_layout =
+            device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("Cef Pipeline Layout"),
+                bind_group_layouts: &[&texture_bind_group_layout],
+                immediate_size: 0,
+            });
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("Cef Render Pipeline"),
+            layout: Some(&render_pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                buffers: &[Vertex::desc()],
+                compilation_options: Default::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: wgpu::TextureFormat::Bgra8Unorm,
+                    blend: None,
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: Default::default(),
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleStrip,
+                strip_index_format: None,
+                front_face: wgpu::FrontFace::Cw,
+                cull_mode: None,
+                polygon_mode: wgpu::PolygonMode::Fill,
+                unclipped_depth: false,
+                conservative: false,
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState {
+                count: 1,
+                mask: !0,
+                alpha_to_coverage_enabled: false,
+            },
+            multiview_mask: None,
+            cache: None,
+        });
+        let quad = Geometry::new(&device);
+
+        let state = State {
+            window,
+            pipeline,
+            device,
+            queue,
+            size,
+            surface,
+            surface_format,
+            quad,
+        };
+
+        state.configure_surface();
+
+        state
+    }
+
+    fn get_window(&self) -> &Window {
+        &self.window
+    }
+
+    fn configure_surface(&self) {
+        let surface_config = wgpu::SurfaceConfiguration {
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            format: self.surface_format,
+            view_formats: vec![self.surface_format],
+            alpha_mode: wgpu::CompositeAlphaMode::Auto,
+            width: self.size.width,
+            height: self.size.height,
+            desired_maximum_frame_latency: 2,
+            present_mode: wgpu::PresentMode::AutoVsync,
+        };
+        self.surface.configure(&self.device, &surface_config);
+    }
+
+    fn resize(&mut self, new_size: winit::dpi::PhysicalSize<u32>) {
+        if new_size.width > 0 && new_size.height > 0 {
+            self.size = new_size;
+            self.configure_surface();
+        }
+    }
+
+    fn render(&mut self) {
+        static RENDER_TID_LOGGED: std::sync::Once = std::sync::Once::new();
+        RENDER_TID_LOGGED.call_once(|| {
+            eprintln!(
+                "cef-osr-dawn render thread: {:?}",
+                std::thread::current().id()
+            );
+        });
+        let surface_texture = self
+            .surface
+            .get_current_texture()
+            .expect("failed to acquire next swapchain texture");
+        let frame = surface_texture
+            .texture
+            .create_view(&wgpu::TextureViewDescriptor {
+                label: Some("Surface"),
+                format: Some(wgpu::TextureFormat::Bgra8Unorm),
+                ..Default::default()
+            });
+
+        let mut encoder = self
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("Render Encoder"),
+            });
+        let maybe_lock = texture_slot().lock().ok();
+        let Some(textures) = maybe_lock.as_ref() else {
+            return;
+        };
+        let Some(bind_group) = textures.as_ref() else {
+            return;
+        };
+        static RENDER_WITH_TEXTURE_LOGGED: std::sync::Once = std::sync::Once::new();
+        RENDER_WITH_TEXTURE_LOGGED.call_once(|| {
+            eprintln!("cef-osr-dawn render: acquired texture bind group");
+        });
+        {
+            let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("Cef Render Pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &frame,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                        store: wgpu::StoreOp::Store,
+                    },
+                    depth_slice: None,
+                })],
+                ..Default::default()
+            });
+            render_pass.set_pipeline(&self.pipeline);
+            render_pass.set_bind_group(0, bind_group, &[]);
+            render_pass.set_vertex_buffer(0, self.quad.vertex_buffer.slice(..));
+            render_pass.draw(0..self.quad.vertex_count, 0..1);
+        }
+        self.queue.submit(std::iter::once(encoder.finish()));
+
+        self.window.pre_present_notify();
+        surface_texture.present();
+    }
+}
+
+struct App {
+    state: Option<State>,
+    browser: Option<Browser>,
+    accelerated_osr: bool,
+}
+
+struct Browser {
+    browser: cef::Browser,
+    size: std::rc::Rc<RefCell<winit::dpi::LogicalSize<f32>>>,
+}
+
+impl App {
+    fn new() -> Self {
+        App {
+            state: None,
+            browser: None,
+            accelerated_osr: false,
+        }
+    }
+}
+
+impl ApplicationHandler for App {
+    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+        let window = Arc::new(
+            event_loop
+                .create_window(WindowAttributes::default())
+                .unwrap(),
+        );
+
+        let state = pollster::block_on(State::new(window.clone()));
+        self.state = Some(state);
+        let accelerated_osr = cfg!(all(
+            any(
+                target_os = "macos",
+                target_os = "windows",
+                target_os = "linux"
+            ),
+            feature = "accelerated_osr"
+        ));
+        eprintln!("cef-osr-dawn accelerated_osr={accelerated_osr}");
+        self.accelerated_osr = accelerated_osr;
+        let window_info = WindowInfo {
+            windowless_rendering_enabled: true as _,
+            shared_texture_enabled: accelerated_osr as _,
+            external_begin_frame_enabled: accelerated_osr as _,
+            ..Default::default()
+        };
+
+        let device_scale_factor = window.scale_factor();
+        let (render_handler, browser_size) = OsrRenderHandler::new(
+            self.state.as_ref().unwrap().device.clone(),
+            self.state.as_ref().unwrap().queue.clone(),
+            device_scale_factor as _,
+            window.inner_size().to_logical(device_scale_factor),
+        );
+
+        let browser_settings = BrowserSettings {
+            windowless_frame_rate: 60,
+            ..Default::default()
+        };
+        let mut context = cef::request_context_create_context(
+            Some(&RequestContextSettings::default()),
+            Some(&mut RequestContextHandlerBuilder::build(
+                OsrRequestContextHandler {},
+            )),
+        );
+
+        let browser = cef::browser_host_create_browser_sync(
+            Some(&window_info),
+            Some(&mut ClientBuilder::build(render_handler)),
+            Some(&"https://github.com".into()),
+            Some(&browser_settings),
+            None,
+            context.as_mut(),
+        );
+        assert!(browser.is_some());
+
+        self.browser.replace(Browser {
+            browser: browser.unwrap(),
+            size: browser_size,
+        });
+
+        window.request_redraw();
+    }
+
+    fn window_event(&mut self, event_loop: &ActiveEventLoop, _id: WindowId, event: WindowEvent) {
+        let state = self.state.as_mut().unwrap();
+        match event {
+            WindowEvent::CloseRequested => {
+                event_loop.exit();
+            }
+            WindowEvent::RedrawRequested => {
+                #[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
+                if self.accelerated_osr {
+                    if let Some(host) = self.browser.as_mut().and_then(|b| b.browser.host()) {
+                        host.send_external_begin_frame();
+                    }
+                }
+                state.render();
+                state.get_window().request_redraw();
+            }
+            WindowEvent::Resized(size) => {
+                state.resize(size);
+                if let Some(browser) = self.browser.as_mut() {
+                    *browser.size.borrow_mut() =
+                        size.to_logical(self.state.as_ref().unwrap().get_window().scale_factor());
+                    if let Some(host) = self.browser.as_mut().and_then(|b| b.browser.host()) {
+                        host.was_resized();
+                    }
+                }
+            }
+            _ => (),
+        }
+    }
+}
+
+fn main() -> std::process::ExitCode {
+    #[cfg(all(target_os = "windows", debug_assertions))]
+    {
+        _ = pix::load_winpix_gpu_capturer();
+    }
+
+    #[cfg(target_os = "macos")]
+    let _loader = {
+        let loader = library_loader::LibraryLoader::new(&std::env::current_exe().unwrap(), false);
+        assert!(loader.load());
+        loader
+    };
+
+    env_logger::init();
+
+    let _ = api_hash(sys::CEF_API_VERSION_LAST, 0);
+
+    let args = Args::new();
+    let cmd = args.as_cmd_line().unwrap();
+
+    let switch = CefString::from("type");
+    let is_browser_process = cmd.has_switch(Some(&switch)) != 1;
+    let mut app = webrender::AppBuilder::build(OsrApp::new());
+    let ret = execute_process(
+        Some(args.as_main_args()),
+        Some(&mut app),
+        std::ptr::null_mut(),
+    );
+
+    if is_browser_process {
+        assert!(ret == -1, "cannot execute browser process");
+    } else {
+        let process_type = CefString::from(&cmd.switch_value(Some(&switch)));
+        println!("launch process {process_type}");
+        assert!(ret >= 0, "cannot execute non-browser process");
+        // non-browser process does not initialize cef
+        return 0.into();
+    }
+    let root_cache_path = format!("/tmp/cef-osr-dawn-cache-{}", std::process::id());
+    let settings = Settings {
+        windowless_rendering_enabled: true as _,
+        external_message_pump: true as _,
+        root_cache_path: root_cache_path.as_str().into(),
+        ..Default::default()
+    };
+    assert_eq!(
+        initialize(
+            Some(args.as_main_args()),
+            Some(&settings),
+            Some(&mut app),
+            std::ptr::null_mut(),
+        ),
+        1
+    );
+
+    let mut event_loop = EventLoop::new().unwrap();
+
+    event_loop.set_control_flow(ControlFlow::Poll);
+
+    let mut app = App::new();
+    let ret = loop {
+        do_message_loop_work();
+        let timeout = Some(Duration::ZERO);
+        let status = event_loop.pump_app_events(timeout, &mut app);
+
+        if let PumpStatus::Exit(exit_code) = status {
+            break ExitCode::from(exit_code as u8);
+        }
+
+        sleep(Duration::from_millis(1000 / 17));
+    };
+    cef::shutdown();
+    ret
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+struct Vertex {
+    position: [f32; 3],
+    tex_coords: [f32; 2],
+}
+
+impl Vertex {
+    const ATTRIBS: [wgpu::VertexAttribute; 2] =
+        wgpu::vertex_attr_array![0 => Float32x3, 1 => Float32x2];
+
+    fn desc<'a>() -> wgpu::VertexBufferLayout<'a> {
+        wgpu::VertexBufferLayout {
+            array_stride: std::mem::size_of::<Self>() as wgpu::BufferAddress,
+            step_mode: wgpu::VertexStepMode::Vertex,
+            attributes: &Self::ATTRIBS,
+        }
+    }
+}
+
+struct Geometry {
+    vertex_buffer: wgpu::Buffer,
+    vertex_count: u32,
+}
+
+impl Geometry {
+    fn new(device: &wgpu::Device) -> Self {
+        let x = -1.0;
+        let y = 1.0;
+        let width = 2.0;
+        let height = 2.0;
+        let z = 0.0; // Center of clip-space depth range
+
+        let vertices = [
+            Vertex {
+                position: [x, y, z],
+                tex_coords: [0.0, 0.0],
+            },
+            Vertex {
+                position: [x + width, y, z],
+                tex_coords: [1.0, 0.0],
+            },
+            Vertex {
+                position: [x, y - height, z],
+                tex_coords: [0.0, 1.0],
+            },
+            Vertex {
+                position: [x + width, y - height, z],
+                tex_coords: [1.0, 1.0],
+            },
+        ];
+
+        let vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("Quad Vertex Buffer"),
+            contents: bytemuck::cast_slice(&vertices),
+            usage: wgpu::BufferUsages::VERTEX,
+        });
+
+        Self {
+            vertex_buffer,
+            vertex_count: vertices.len() as u32,
+        }
+    }
+}
+
+#[cfg(all(target_os = "windows", debug_assertions))]
+mod pix {
+    use libloading::Library;
+    use std::io::{Error, ErrorKind, Result};
+    use std::path::PathBuf;
+    use windows::Win32::System::LibraryLoader::GetModuleHandleW;
+    use windows::core::{HSTRING, PCWSTR};
+
+    fn get_latest_winpix_gpu_capturer_path() -> PathBuf {
+        PathBuf::from(r"C:\Program Files")
+            .join("Microsoft PIX")
+            .join("2601.15")
+            .join("WinPixGpuCapturer.dll")
+    }
+
+    pub fn load_winpix_gpu_capturer() -> Result<()> {
+        let module_name = HSTRING::from("WinPixGpuCapturer.dll");
+
+        unsafe {
+            let module_pcwstr = PCWSTR::from_raw(module_name.as_ptr());
+            let is_loaded = GetModuleHandleW(module_pcwstr).is_ok();
+
+            if !is_loaded {
+                let path = get_latest_winpix_gpu_capturer_path();
+
+                if !path.exists() {
+                    return Err(Error::new(
+                        ErrorKind::NotFound,
+                        format!("WinPixGpuCapturer.dll not found at {}", path.display()),
+                    ));
+                }
+
+                match Library::new(&path) {
+                    Ok(lib) => {
+                        use std::sync::Once;
+                        static INIT: Once = Once::new();
+                        static mut LIBRARY: Option<Library> = None;
+
+                        INIT.call_once(|| {
+                            LIBRARY = Some(lib);
+                        });
+
+                        Ok(())
+                    }
+                    Err(e) => Err(Error::other(format!(
+                        "Failed to load WinPixGpuCapturer.dll: {e}"
+                    ))),
+                }
+            } else {
+                Ok(())
+            }
+        }
+    }
+}

--- a/examples/osr_dawn/src/shader.wgsl
+++ b/examples/osr_dawn/src/shader.wgsl
@@ -1,0 +1,28 @@
+// Vertex shader
+struct VertexInput {
+    @location(0) pos: vec4<f32>,
+    @location(1) tex: vec2<f32>,
+};
+
+struct VertexOutput {
+    @builtin(position) pos: vec4<f32>,
+    @location(0) tex: vec2<f32>,
+};
+
+@vertex
+fn vs_main(input: VertexInput) -> VertexOutput {
+    var output: VertexOutput;
+    output.pos = input.pos;
+    output.tex = input.tex;
+    return output;
+}
+
+// Fragment shader
+@group(0) @binding(0) var tex0: texture_2d<f32>;
+@group(0) @binding(1) var samp0: sampler;
+
+@fragment
+fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
+    return textureSample(tex0, samp0, input.tex);
+}
+

--- a/examples/osr_dawn/src/webrender.rs
+++ b/examples/osr_dawn/src/webrender.rs
@@ -1,0 +1,393 @@
+use cef::{
+    self, BrowserProcessHandler, ImplBrowserProcessHandler, WrapBrowserProcessHandler, rc::Rc, *,
+};
+use cef::{ImplRequestContextHandler, RequestContextHandler, WrapRequestContextHandler};
+use std::cell::RefCell;
+use std::sync::{Mutex, OnceLock};
+
+fn update_texture_bind_group(device: &wgpu::Device, texture: &wgpu::Texture) {
+    static BINDGROUP_UPDATED: std::sync::Once = std::sync::Once::new();
+    let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+        address_mode_u: wgpu::AddressMode::ClampToEdge,
+        address_mode_v: wgpu::AddressMode::ClampToEdge,
+        address_mode_w: wgpu::AddressMode::ClampToEdge,
+        mag_filter: wgpu::FilterMode::Linear,
+        min_filter: wgpu::FilterMode::Linear,
+        mipmap_filter: wgpu::MipmapFilterMode::Linear,
+        ..Default::default()
+    });
+
+    let texture_bind_group_layout =
+        device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("Cef Texture Bind Group Layout"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        multisampled: false,
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
+            ],
+        });
+
+    let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("Cef Texture Bind Group"),
+        layout: &texture_bind_group_layout,
+        entries: &[
+            wgpu::BindGroupEntry {
+                binding: 0,
+                resource: wgpu::BindingResource::TextureView(&texture.create_view(
+                    &wgpu::TextureViewDescriptor {
+                        label: Some("Cef Texture View"),
+                        ..Default::default()
+                    },
+                )),
+            },
+            wgpu::BindGroupEntry {
+                binding: 1,
+                resource: wgpu::BindingResource::Sampler(&sampler),
+            },
+        ],
+    });
+
+    if let Ok(mut slot) = texture_slot().lock() {
+        slot.replace(bind_group);
+        BINDGROUP_UPDATED.call_once(|| {
+            eprintln!("cef-osr-dawn texture bind group updated");
+        });
+    }
+}
+
+
+#[derive(Clone)]
+pub struct OsrApp {}
+
+impl OsrApp {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+wrap_app! {
+    pub(crate) struct AppBuilder {
+        app: OsrApp,
+    }
+
+    impl App {
+        fn on_before_command_line_processing(
+            &self,
+            _process_type: Option<&cef::CefStringUtf16>,
+            command_line: Option<&mut cef::CommandLine>,
+        ) {
+            let Some(command_line) = command_line else {
+                return;
+            };
+
+            command_line.append_switch(Some(&"no-startup-window".into()));
+            command_line.append_switch(Some(&"noerrdialogs".into()));
+            command_line.append_switch(Some(&"hide-crash-restore-bubble".into()));
+            command_line.append_switch(Some(&"use-mock-keychain".into()));
+            command_line.append_switch(Some(&"enable-logging=stderr".into()));
+            command_line.append_switch_with_value(
+                Some(&"remote-debugging-port".into()),
+                Some(&"9229".into()),
+            );
+        }
+
+        fn browser_process_handler(&self) -> Option<cef::BrowserProcessHandler> {
+            Some(BrowserProcessHandlerBuilder::build(
+                OsrBrowserProcessHandler::new(),
+            ))
+        }
+    }
+}
+
+impl AppBuilder {
+    pub(crate) fn build(app: OsrApp) -> cef::App {
+        Self::new(app)
+    }
+}
+
+#[derive(Clone)]
+pub struct OsrBrowserProcessHandler {
+    is_cef_ready: RefCell<bool>,
+}
+
+impl OsrBrowserProcessHandler {
+    pub fn new() -> Self {
+        Self {
+            is_cef_ready: RefCell::new(false),
+        }
+    }
+}
+
+wrap_browser_process_handler! {
+    pub(crate) struct BrowserProcessHandlerBuilder {
+        handler: OsrBrowserProcessHandler,
+    }
+
+    impl BrowserProcessHandler {
+        fn on_context_initialized(&self) {
+            *self.handler.is_cef_ready.borrow_mut() = true;
+        }
+
+        fn on_before_child_process_launch(&self, command_line: Option<&mut CommandLine>) {
+            let Some(command_line) = command_line else {
+                return;
+            };
+
+            command_line.append_switch(Some(&"disable-web-security".into()));
+            command_line.append_switch(Some(&"allow-running-insecure-content".into()));
+            command_line.append_switch(Some(&"disable-session-crashed-bubble".into()));
+            command_line.append_switch(Some(&"ignore-certificate-errors".into()));
+            command_line.append_switch(Some(&"ignore-ssl-errors".into()));
+            command_line.append_switch(Some(&"enable-logging=stderr".into()));
+        }
+    }
+}
+
+impl BrowserProcessHandlerBuilder {
+    pub(crate) fn build(handler: OsrBrowserProcessHandler) -> BrowserProcessHandler {
+        Self::new(handler)
+    }
+}
+
+#[derive(Clone)]
+pub struct OsrRenderHandler {
+    device_scale_factor: f32,
+    size: std::rc::Rc<RefCell<winit::dpi::LogicalSize<f32>>>,
+    _device: wgpu::Device,
+    _queue: wgpu::Queue,
+}
+
+impl OsrRenderHandler {
+    pub fn new(
+        _device: wgpu::Device,
+        _queue: wgpu::Queue,
+        device_scale_factor: f32,
+        size: winit::dpi::LogicalSize<f32>,
+    ) -> (Self, std::rc::Rc<RefCell<winit::dpi::LogicalSize<f32>>>) {
+        let size = std::rc::Rc::new(RefCell::new(size));
+        (
+            Self {
+                size: size.clone(),
+                device_scale_factor,
+                _device,
+                _queue,
+            },
+            size,
+        )
+    }
+}
+
+wrap_render_handler! {
+    pub struct RenderHandlerBuilder {
+        handler: OsrRenderHandler,
+    }
+
+    impl RenderHandler {
+        fn view_rect(&self, _browser: Option<&mut Browser>, rect: Option<&mut Rect>) {
+            if let Some(rect) = rect {
+                let size = self.handler.size.borrow();
+                // size must be non-zero
+                if size.width > 0.0 && size.height > 0.0 {
+                    rect.width = size.width as _;
+                    rect.height = size.height as _;
+                }
+            }
+        }
+
+        fn screen_info(
+            &self,
+            _browser: Option<&mut Browser>,
+            screen_info: Option<&mut ScreenInfo>,
+        ) -> ::std::os::raw::c_int {
+            if let Some(screen_info) = screen_info {
+                screen_info.device_scale_factor = self.handler.device_scale_factor;
+                return true as _;
+            }
+            false as _
+        }
+
+        fn screen_point(
+            &self,
+            _browser: Option<&mut Browser>,
+            _view_x: ::std::os::raw::c_int,
+            _view_y: ::std::os::raw::c_int,
+            _screen_x: Option<&mut ::std::os::raw::c_int>,
+            _screen_y: Option<&mut ::std::os::raw::c_int>,
+        ) -> ::std::os::raw::c_int {
+            false as _
+        }
+
+        #[cfg(all(
+            any(target_os = "macos", target_os = "windows", target_os = "linux"),
+            feature = "accelerated_osr"
+        ))]
+        fn on_accelerated_paint(
+            &self,
+            _browser: Option<&mut Browser>,
+            type_: PaintElementType,
+            _dirty_rects: Option<&[Rect]>,
+            info: Option<&AcceleratedPaintInfo>,
+        ) {
+            static ON_ACCEL_LOGGED: std::sync::Once = std::sync::Once::new();
+            let Some(info) = info else { return };
+            ON_ACCEL_LOGGED.call_once(|| {
+                eprintln!(
+                    "cef-osr-dawn on_accelerated_paint called: type={:?}, coded_size={}x{}, thread={:?}",
+                    type_,
+                    info.extra.coded_size.width,
+                    info.extra.coded_size.height,
+                    std::thread::current().id()
+                );
+            });
+            if type_ != PaintElementType::default() {
+                return;
+            }
+
+            let src_texture = {
+                use cef::osr_texture_import::shared_texture_handle::SharedTextureHandle;
+                let shared_handle = SharedTextureHandle::new(info);
+                if let SharedTextureHandle::Unsupported = shared_handle {
+                    eprintln!("Platform does not support accelerated painting");
+                    return;
+                }
+                match shared_handle.import_texture(&self.handler._device) {
+                    Ok(texture) => texture,
+                    Err(e) => {
+                        eprintln!("Failed to import shared texture: {:?}", e);
+                        return;
+                    }
+                }
+            };
+            update_texture_bind_group(&self.handler._device, &src_texture);
+        }
+
+        #[cfg(all(
+            any(target_os = "macos", target_os = "windows", target_os = "linux"),
+            feature = "accelerated_osr"
+        ))]
+        fn on_paint(
+            &self,
+            _browser: Option<&mut Browser>,
+            _type_: PaintElementType,
+            _dirty_rects: Option<&[Rect]>,
+            buffer: *const u8,
+            width: ::std::os::raw::c_int,
+            height: ::std::os::raw::c_int,
+        ) {
+            use wgpu::{Extent3d, TextureDescriptor, TextureDimension, TextureUsages};
+            static ON_PAINT_LOGGED: std::sync::Once = std::sync::Once::new();
+
+            if buffer.is_null() || width <= 0 || height <= 0 {
+                return;
+            }
+            ON_PAINT_LOGGED.call_once(|| {
+                eprintln!(
+                    "cef-osr-dawn on_paint active: {}x{}, thread={:?}",
+                    width,
+                    height,
+                    std::thread::current().id()
+                );
+            });
+
+            let buffer_size = (width * height * 4) as usize; // BGRA format
+            let buffer_slice = unsafe { std::slice::from_raw_parts(buffer, buffer_size) };
+
+            // Create texture from CEF paint buffer
+            let texture_desc = TextureDescriptor {
+                label: Some("CEF Paint Texture"),
+                size: Extent3d {
+                    width: width as u32,
+                    height: height as u32,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: TextureDimension::D2,
+                format: wgpu::TextureFormat::Bgra8Unorm,
+                usage: TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_DST,
+                view_formats: &[],
+            };
+
+            let texture = self.handler._device.create_texture(&texture_desc);
+
+            // Upload the CEF buffer data to the texture
+            self.handler._queue.write_texture(
+                wgpu::TexelCopyTextureInfo {
+                    texture: &texture,
+                    mip_level: 0,
+                    origin: wgpu::Origin3d::ZERO,
+                    aspect: wgpu::TextureAspect::All,
+                },
+                buffer_slice,
+                wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(4 * width as u32),
+                    rows_per_image: Some(height as u32),
+                },
+                texture_desc.size,
+            );
+
+            update_texture_bind_group(&self.handler._device, &texture);
+        }
+    }
+}
+
+impl RenderHandlerBuilder {
+    pub fn build(handler: OsrRenderHandler) -> RenderHandler {
+        Self::new(handler)
+    }
+}
+
+static TEXTURE: OnceLock<Mutex<Option<wgpu::BindGroup>>> = OnceLock::new();
+
+pub(crate) fn texture_slot() -> &'static Mutex<Option<wgpu::BindGroup>> {
+    TEXTURE.get_or_init(|| Mutex::new(None))
+}
+
+wrap_client! {
+    pub(crate) struct ClientBuilder {
+        render_handler: RenderHandler,
+    }
+
+    impl Client {
+        fn render_handler(&self) -> Option<cef::RenderHandler> {
+            Some(self.render_handler.clone())
+        }
+    }
+}
+
+impl ClientBuilder {
+    pub(crate) fn build(render_handler: OsrRenderHandler) -> Client {
+        Self::new(RenderHandlerBuilder::build(render_handler))
+    }
+}
+
+#[derive(Clone)]
+pub struct OsrRequestContextHandler {}
+
+wrap_request_context_handler! {
+    pub(crate) struct RequestContextHandlerBuilder {
+        handler: OsrRequestContextHandler,
+    }
+
+    impl RequestContextHandler {}
+}
+
+impl RequestContextHandlerBuilder {
+    pub(crate) fn build(handler: OsrRequestContextHandler) -> RequestContextHandler {
+        Self::new(handler)
+    }
+}


### PR DESCRIPTION
Introduce https://github.com/google/dawn as an alternative gpu api of wgpu, which is already deployed in chrome, should be more stable and performant thant wgpu.

With dawn's wire mode, cef's OSR can unblock cross-process gpu rendering like chrome with detaching gpu from the main process, it will prevent the host app from crashing caused by gpu.