### PR TITLE
feat: include cef_color_ids.h in code generation

### DIFF
--- a/sys/wrapper.h
+++ b/sys/wrapper.h
@@ -110,5 +110,6 @@
 #include "include/capi/views/cef_view_delegate_capi.h"
 #include "include/capi/views/cef_window_capi.h"
 #include "include/capi/views/cef_window_delegate_capi.h"
+#include "include/cef_color_ids.h"
 
 #endif


### PR DESCRIPTION
This is needed to generate `CEF_ColorPrimaryBackground` constant which can change in any CEF release.

I am not sure how to generate the bindings though, but seems like it is auto-generated and PR'd after merge?