### PR TITLE
feat: improve CEF_PATH usage

### DIFF
--- a/sys/build.rs
+++ b/sys/build.rs
@@ -69,8 +69,19 @@ fn main() -> anyhow::Result<()> {
                     "Using CEF path from environment: {}",
                     configured_path.display()
                 );
-                check_archive(&configured_path)?;
-                configured_path
+                match check_archive(&configured_path) {
+                    Ok(()) => configured_path,
+                    Err(error) => {
+                        let versioned_location = configured_path.join(&cef_version);
+                        println!(
+                            "CEF_PATH is invalid ({error}), downloading archive to: {}",
+                            versioned_location.display()
+                        );
+                        let resolved = resolve_cef_dir(&versioned_location)?;
+                        println!("Using downloaded CEF path: {}", resolved.display());
+                        resolved
+                    }
+                }
             }
         } else {
             let versioned_location = configured_path.join(&cef_version);

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -46,6 +46,29 @@ fn main() -> anyhow::Result<()> {
         Ok(cef_dir)
     };
 
+    let resolve_from_versioned = |configured_path: &Path| -> anyhow::Result<PathBuf> {
+        let versioned_location = configured_path.join(&cef_version);
+        let resolved = resolve_cef_dir(&versioned_location)?;
+        println!(
+            "Using versioned CEF path from environment: {}",
+            resolved.display()
+        );
+        check_archive(&resolved)?;
+        Ok(resolved)
+    };
+
+    let download_to_versioned =
+        |configured_path: &Path, reason: &str| -> anyhow::Result<PathBuf> {
+            let versioned_location = configured_path.join(&cef_version);
+            println!(
+                "{reason}, downloading archive to: {}",
+                versioned_location.display()
+            );
+            let resolved = resolve_cef_dir(&versioned_location)?;
+            println!("Using downloaded CEF path: {}", resolved.display());
+            Ok(resolved)
+        };
+
     let cef_dir = if env::var("FLATPAK").is_ok() {
         let cef_path = String::from("/usr/lib");
         println!("Using CEF path from FLATPAK: {cef_path}");
@@ -57,13 +80,7 @@ fn main() -> anyhow::Result<()> {
         if fs::exists(&configured_path)? {
             let versioned_location = configured_path.join(&cef_version);
             if fs::exists(&versioned_location)? {
-                let resolved = resolve_cef_dir(&versioned_location)?;
-                println!(
-                    "Using versioned CEF path from environment: {}",
-                    resolved.display()
-                );
-                check_archive(&resolved)?;
-                resolved
+                resolve_from_versioned(&configured_path)?
             } else {
                 println!(
                     "Using CEF path from environment: {}",
@@ -71,27 +88,14 @@ fn main() -> anyhow::Result<()> {
                 );
                 match check_archive(&configured_path) {
                     Ok(()) => configured_path,
-                    Err(error) => {
-                        let versioned_location = configured_path.join(&cef_version);
-                        println!(
-                            "CEF_PATH is invalid ({error}), downloading archive to: {}",
-                            versioned_location.display()
-                        );
-                        let resolved = resolve_cef_dir(&versioned_location)?;
-                        println!("Using downloaded CEF path: {}", resolved.display());
-                        resolved
-                    }
+                    Err(error) => download_to_versioned(
+                        &configured_path,
+                        &format!("CEF_PATH is invalid ({error})"),
+                    )?,
                 }
             }
         } else {
-            let versioned_location = configured_path.join(&cef_version);
-            println!(
-                "CEF_PATH does not exist, downloading archive to: {}",
-                versioned_location.display()
-            );
-            let resolved = resolve_cef_dir(&versioned_location)?;
-            println!("Using downloaded CEF path: {}", resolved.display());
-            resolved
+            download_to_versioned(&configured_path, "CEF_PATH does not exist")?
         }
     } else {
         let out_dir = PathBuf::from(env::var("OUT_DIR")?);

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -57,17 +57,16 @@ fn main() -> anyhow::Result<()> {
         Ok(resolved)
     };
 
-    let download_to_versioned =
-        |configured_path: &Path, reason: &str| -> anyhow::Result<PathBuf> {
-            let versioned_location = configured_path.join(&cef_version);
-            println!(
-                "{reason}, downloading archive to: {}",
-                versioned_location.display()
-            );
-            let resolved = resolve_cef_dir(&versioned_location)?;
-            println!("Using downloaded CEF path: {}", resolved.display());
-            Ok(resolved)
-        };
+    let download_to_versioned = |configured_path: &Path, reason: &str| -> anyhow::Result<PathBuf> {
+        let versioned_location = configured_path.join(&cef_version);
+        println!(
+            "{reason}, downloading archive to: {}",
+            versioned_location.display()
+        );
+        let resolved = resolve_cef_dir(&versioned_location)?;
+        println!("Using downloaded CEF path: {}", resolved.display());
+        Ok(resolved)
+    };
 
     let cef_dir = if env::var("FLATPAK").is_ok() {
         let cef_path = String::from("/usr/lib");

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -30,7 +30,8 @@ fn main() -> anyhow::Result<()> {
             let version = platform.version(&cef_version)?;
 
             let archive = version.download_archive(location, false)?;
-            let extracted_dir = download_cef::extract_target_archive(&target, &archive, location, false)?;
+            let extracted_dir =
+                download_cef::extract_target_archive(&target, &archive, location, false)?;
             if extracted_dir != cef_dir {
                 return Err(anyhow::anyhow!(
                     "extracted dir {extracted_dir:?} does not match cef_dir {cef_dir:?}",
@@ -62,7 +63,10 @@ fn main() -> anyhow::Result<()> {
                 check_archive(&resolved)?;
                 resolved
             } else {
-                println!("Using CEF path from environment: {}", configured_path.display());
+                println!(
+                    "Using CEF path from environment: {}",
+                    configured_path.display()
+                );
                 check_archive(&configured_path)?;
                 configured_path
             }

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -1,7 +1,10 @@
 #[cfg(not(feature = "dox"))]
 fn main() -> anyhow::Result<()> {
     use download_cef::{CefIndex, OsAndArch};
-    use std::{env, fs, path::PathBuf};
+    use std::{
+        env, fs,
+        path::{Path, PathBuf},
+    };
 
     println!("cargo::rerun-if-changed=build.rs");
 
@@ -10,42 +13,72 @@ fn main() -> anyhow::Result<()> {
 
     println!("cargo::rerun-if-env-changed=FLATPAK");
     println!("cargo::rerun-if-env-changed=CEF_PATH");
-    let cef_path_env = env::var("FLATPAK")
-        .map(|_| String::from("/usr/lib"))
-        .or_else(|_| env::var("CEF_PATH"));
+    let package_version = env::var("CARGO_PKG_VERSION")?;
+    let cef_version = download_cef::default_version(&package_version);
 
-    let cef_dir = match cef_path_env {
-        Ok(cef_path) => {
-            // Allow overriding the CEF path with environment variables.
-            println!("Using CEF path from environment: {cef_path}");
-            download_cef::check_archive_json(&env::var("CARGO_PKG_VERSION")?, &cef_path)?;
-            PathBuf::from(cef_path)
-        }
-        Err(_) => {
-            let out_dir = PathBuf::from(env::var("OUT_DIR")?);
-            let cef_dir = os_arch.to_string();
-            let cef_dir = out_dir.join(&cef_dir);
+    let check_archive = |path: &Path| -> anyhow::Result<()> {
+        download_cef::check_archive_json(&package_version, &path.display().to_string())?;
+        Ok(())
+    };
 
-            if !fs::exists(&cef_dir)? {
-                let cef_version = download_cef::default_version(&env::var("CARGO_PKG_VERSION")?);
-                let index = CefIndex::download()?;
-                let platform = index.platform(&target)?;
-                let version = platform.version(&cef_version)?;
+    let resolve_cef_dir = |location: &Path| -> anyhow::Result<PathBuf> {
+        let cef_dir = location.join(os_arch.to_string());
 
-                let archive = version.download_archive(&out_dir, false)?;
-                let extracted_dir =
-                    download_cef::extract_target_archive(&target, &archive, &out_dir, false)?;
-                if extracted_dir != cef_dir {
-                    return Err(anyhow::anyhow!(
-                        "extracted dir {extracted_dir:?} does not match cef_dir {cef_dir:?}",
-                    ));
-                }
+        if !fs::exists(&cef_dir)? {
+            let index = CefIndex::download()?;
+            let platform = index.platform(&target)?;
+            let version = platform.version(&cef_version)?;
 
-                version.write_archive_json(extracted_dir)?;
+            let archive = version.download_archive(location, false)?;
+            let extracted_dir = download_cef::extract_target_archive(&target, &archive, location, false)?;
+            if extracted_dir != cef_dir {
+                return Err(anyhow::anyhow!(
+                    "extracted dir {extracted_dir:?} does not match cef_dir {cef_dir:?}",
+                ));
             }
 
-            cef_dir
+            version.write_archive_json(extracted_dir)?;
         }
+
+        Ok(cef_dir)
+    };
+
+    let cef_dir = if env::var("FLATPAK").is_ok() {
+        let cef_path = String::from("/usr/lib");
+        println!("Using CEF path from FLATPAK: {cef_path}");
+        let cef_path = PathBuf::from(cef_path);
+        check_archive(&cef_path)?;
+        cef_path
+    } else if let Ok(cef_path) = env::var("CEF_PATH") {
+        let configured_path = PathBuf::from(cef_path);
+        if fs::exists(&configured_path)? {
+            let versioned_location = configured_path.join(&cef_version);
+            if fs::exists(&versioned_location)? {
+                let resolved = resolve_cef_dir(&versioned_location)?;
+                println!(
+                    "Using versioned CEF path from environment: {}",
+                    resolved.display()
+                );
+                check_archive(&resolved)?;
+                resolved
+            } else {
+                println!("Using CEF path from environment: {}", configured_path.display());
+                check_archive(&configured_path)?;
+                configured_path
+            }
+        } else {
+            let versioned_location = configured_path.join(&cef_version);
+            println!(
+                "CEF_PATH does not exist, downloading archive to: {}",
+                versioned_location.display()
+            );
+            let resolved = resolve_cef_dir(&versioned_location)?;
+            println!("Using downloaded CEF path: {}", resolved.display());
+            resolved
+        }
+    } else {
+        let out_dir = PathBuf::from(env::var("OUT_DIR")?);
+        resolve_cef_dir(&out_dir)?
     };
 
     let cef_dir = cef_dir.display().to_string();

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -17,7 +17,7 @@ fn main() -> anyhow::Result<()> {
     let cef_version = download_cef::default_version(&package_version);
 
     let check_archive = |path: &Path| -> anyhow::Result<()> {
-        download_cef::check_archive_json(&package_version, &path.display().to_string())?;
+        download_cef::check_archive_json(&package_version, &path.to_string_lossy())?;
         Ok(())
     };
 
@@ -32,9 +32,11 @@ fn main() -> anyhow::Result<()> {
             let archive = version.download_archive(location, false)?;
             let extracted_dir =
                 download_cef::extract_target_archive(&target, &archive, location, false)?;
-            if extracted_dir != cef_dir {
+            let extracted_dir_canonical = fs::canonicalize(&extracted_dir)?;
+            let cef_dir_canonical = fs::canonicalize(&cef_dir)?;
+            if extracted_dir_canonical != cef_dir_canonical {
                 return Err(anyhow::anyhow!(
-                    "extracted dir {extracted_dir:?} does not match cef_dir {cef_dir:?}",
+                    "extracted dir {extracted_dir_canonical:?} does not match cef_dir {cef_dir_canonical:?}",
                 ));
             }
 
@@ -85,7 +87,7 @@ fn main() -> anyhow::Result<()> {
         resolve_cef_dir(&out_dir)?
     };
 
-    let cef_dir = cef_dir.display().to_string();
+    let cef_dir = cef_dir.to_string_lossy().into_owned();
 
     println!("cargo::metadata=CEF_DIR={cef_dir}");
     println!("cargo::rustc-link-search=native={cef_dir}");
@@ -137,8 +139,8 @@ fn main() -> anyhow::Result<()> {
                 .define("PROJECT_ARCH", project_arch)
                 .define("USE_SANDBOX", sandbox)
                 .build()
-                .display()
-                .to_string();
+                .to_string_lossy()
+                .into_owned();
 
             println!("cargo::rustc-link-search=native={build_dir}/build/libcef_dll_wrapper");
             println!("cargo::rustc-link-lib=static=libcef_dll_wrapper");
@@ -153,8 +155,8 @@ fn main() -> anyhow::Result<()> {
                 .define("PROJECT_ARCH", project_arch)
                 .define("USE_SANDBOX", sandbox)
                 .build()
-                .display()
-                .to_string();
+                .to_string_lossy()
+                .into_owned();
             println!("cargo::rustc-link-search=native={build_dir}/build/libcef_dll_wrapper");
             println!("cargo::rustc-link-lib=static=cef_dll_wrapper");
         }

--- a/sys/src/lib.rs
+++ b/sys/src/lib.rs
@@ -45,7 +45,21 @@ pub fn get_cef_dir() -> Option<PathBuf> {
     match cef_path_env {
         Ok(cef_path) => {
             // Allow overriding the CEF path with environment variables.
-            PathBuf::from(cef_path).canonicalize().ok()
+            let configured_path = PathBuf::from(cef_path);
+            let cef_dir = format!("cef_{OS}_{ARCH}");
+            let package_version = env!("CARGO_PKG_VERSION");
+            let cef_version = package_version
+                .split_once('+')
+                .map(|(_, version)| version)
+                .unwrap_or(package_version);
+
+            [
+                configured_path.join(cef_version).join(&cef_dir),
+                configured_path,
+            ]
+            .into_iter()
+            .find_map(|path| fs::exists(&path).ok()?.then(|| path.canonicalize().ok()))
+            .flatten()
         }
         Err(_) => {
             let out_dir = PathBuf::from(env!("OUT_DIR"));


### PR DESCRIPTION
I've improved `sys/build.rs` CEF path resolution to better handle `CEF_PATH` when it is missing with a fallback behavior: if `CEF_PATH` does not exist, download/extract CEF under `CEF_PATH/<cef-version>/` and use the extracted `cef_<os>_<arch>` directory.

I've also added preference behavior for subsequent runs: when `CEF_PATH` exists, prefer `CEF_PATH/<cef-version>/cef_<os>_<arch>` if `CEF_PATH/<cef-version>` exists; otherwise fall back to direct `CEF_PATH`.

The goal here is to not invalidate cargo build cache when the Tauri CLI runs the build (and sets its own CEF_PATH) with a manual run of cargo build (which can now point to a local directory in the workspace for the CEF cache path, making sure both builds use the same env values)