### PR TITLE
feat: include cef_component_updater_capi.h for CEF >= 147

### DIFF
--- a/sys/wrapper.h
+++ b/sys/wrapper.h
@@ -20,6 +20,9 @@
 #include "include/capi/cef_client_capi.h"
 #include "include/capi/cef_command_handler_capi.h"
 #include "include/capi/cef_command_line_capi.h"
+#if CEF_VERSION_MAJOR >= 147
+#include "include/capi/cef_component_updater_capi.h"
+#endif
 #include "include/capi/cef_context_menu_handler_capi.h"
 #include "include/capi/cef_cookie_capi.h"
 #include "include/capi/cef_crash_util_capi.h"


### PR DESCRIPTION
## Rationale

Hi, thanks to the tauri team for the cef-rs work.

I am the maintainer of chromium-embedded-framework on Debian, a package under revision right now.
I am also updating a debian package for cef-rs https://salsa.debian.org/mendezr/rust-cef
Since Debian Chromium has updated to 147 to prevent vulnerabilities, this PR is to speed up the process by updating what is needed for the rust-cef debian package, by updating this the upstream project.

## Summary

- Add `include/capi/cef_component_updater_capi.h` to `sys/wrapper.h` behind a `#if CEF_VERSION_MAJOR >= 147` guard
- This ensures the first cef-rs release targeting CEF 147 will include the new component updater bindings automatically

No version bump or bindings changes — just the header include so `get-latest` + `update-bindings` will pick it up when CEF 147 stabilizes.