### PR TITLE
feat: copy cef files to target dir on linux and windows

### DIFF
--- a/download-cef/src/lib.rs
+++ b/download-cef/src/lib.rs
@@ -124,7 +124,8 @@ fn archive_json_path<P>(location: P) -> PathBuf
 where
     P: AsRef<Path>,
 {
-    location.as_ref().join("archive.json")
+    let location = location.as_ref().join("archive.json");
+    std::path::absolute(&location).unwrap_or(location)
 }
 
 pub const DEFAULT_CDN_URL: &str = "https://cef-builds.spotifycdn.com";

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -141,7 +141,6 @@ fn main() -> anyhow::Result<()> {
         "linux" => {
             // On Windows and Linux the cef files usually have to be next to the main binary.
             // On macOS it's more complicated so we'll leave it to tools like tauri-cli for now.
-            // TODO: Consider to put this behind a feature flag
             copy_cef_runtime_files(&cef_dir, target_dir)?;
 
             println!("cargo::rustc-link-lib=dylib=cef");
@@ -149,7 +148,6 @@ fn main() -> anyhow::Result<()> {
         "windows" => {
             // On Windows and Linux the cef files usually have to be next to the main binary.
             // On macOS it's more complicated so we'll leave it to tools like tauri-cli for now.
-            // TODO: Consider to put this behind a feature flag
             copy_cef_runtime_files(&cef_dir, target_dir)?;
 
             let sdk_libs = [

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -112,17 +112,13 @@ fn main() -> anyhow::Result<()> {
         .parent()
         .unwrap();
 
-    // On Windows and Linux the cef files usually have to be next to the main binary.
-    // TODO: Consider to put this behind a feature flag
-    copy_cef_runtime_files(&cef_dir, target_dir)?;
-
-    let cef_dir = cef_dir.to_string_lossy().into_owned();
+    let cef_dir_str = cef_dir.to_string_lossy().into_owned();
 
     // Re-run when the resolved CEF directory changes/deletes.
-    println!("cargo::rerun-if-changed={cef_dir}");
+    println!("cargo::rerun-if-changed={cef_dir_str}");
 
-    println!("cargo::metadata=CEF_DIR={cef_dir}");
-    println!("cargo::rustc-link-search=native={cef_dir}");
+    println!("cargo::metadata=CEF_DIR={cef_dir_str}");
+    println!("cargo::rustc-link-search=native={cef_dir_str}");
 
     let mut cef_dll_wrapper = cmake::Config::new(&cef_dir);
     cef_dll_wrapper
@@ -143,9 +139,19 @@ fn main() -> anyhow::Result<()> {
 
     match os_arch.os {
         "linux" => {
+            // On Windows and Linux the cef files usually have to be next to the main binary.
+            // On macOS it's more complicated so we'll leave it to tools like tauri-cli for now.
+            // TODO: Consider to put this behind a feature flag
+            copy_cef_runtime_files(&cef_dir, target_dir)?;
+
             println!("cargo::rustc-link-lib=dylib=cef");
         }
         "windows" => {
+            // On Windows and Linux the cef files usually have to be next to the main binary.
+            // On macOS it's more complicated so we'll leave it to tools like tauri-cli for now.
+            // TODO: Consider to put this behind a feature flag
+            copy_cef_runtime_files(&cef_dir, target_dir)?;
+
             let sdk_libs = [
                 "comctl32.lib",
                 "delayimp.lib",
@@ -200,24 +206,27 @@ fn main() -> anyhow::Result<()> {
 
 #[cfg(not(feature = "dox"))]
 fn copy_directory(src: &std::path::Path, dest: &std::path::Path) -> Result<(), std::io::Error> {
-  std::fs::create_dir_all(dest)?;
-  for entry in std::fs::read_dir(src)? {
-    let entry = entry?;
-    if entry.path().is_file() {
-      std::fs::copy(entry.path(), dest.join(entry.file_name()))?;
+    std::fs::create_dir_all(dest)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        if entry.path().is_file() {
+            std::fs::copy(entry.path(), dest.join(entry.file_name()))?;
+        }
     }
-  }
-  Ok(())
+    Ok(())
 }
 
 #[cfg(not(feature = "dox"))]
-fn copy_cef_runtime_files(cef_dir: &std::path::Path, target_dir: &std::path::Path) -> Result<(), std::io::Error> {
-  copy_directory(cef_dir, target_dir)?;
+fn copy_cef_runtime_files(
+    cef_dir: &std::path::Path,
+    target_dir: &std::path::Path,
+) -> Result<(), std::io::Error> {
+    copy_directory(cef_dir, target_dir)?;
 
-  const LOCALES_DIR: &str = "locales";
-  copy_directory(&cef_dir.join(LOCALES_DIR), &target_dir.join(LOCALES_DIR))?;
+    const LOCALES_DIR: &str = "locales";
+    copy_directory(&cef_dir.join(LOCALES_DIR), &target_dir.join(LOCALES_DIR))?;
 
-  Ok(())
+    Ok(())
 }
 
 #[cfg(feature = "dox")]

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -69,6 +69,8 @@ fn main() -> anyhow::Result<()> {
         Ok(resolved)
     };
 
+    let out_dir = PathBuf::from(env::var("OUT_DIR")?);
+
     let cef_dir = if env::var("FLATPAK").is_ok() {
         let cef_path = String::from("/usr/lib");
         println!("Using CEF path from FLATPAK: {cef_path}");
@@ -98,9 +100,21 @@ fn main() -> anyhow::Result<()> {
             download_to_versioned(&configured_path, "CEF_PATH does not exist")?
         }
     } else {
-        let out_dir = PathBuf::from(env::var("OUT_DIR")?);
         resolve_cef_dir(&out_dir)?
     };
+
+    // TODO: far from ideal, but there's no other way to get the target dir, see <https://github.com/rust-lang/cargo/issues/9661>
+    let target_dir = out_dir
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap();
+
+    // On Windows and Linux the cef files usually have to be next to the main binary.
+    // TODO: Consider to put this behind a feature flag
+    copy_cef_runtime_files(&cef_dir, target_dir)?;
 
     let cef_dir = cef_dir.to_string_lossy().into_owned();
 
@@ -182,6 +196,28 @@ fn main() -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(not(feature = "dox"))]
+fn copy_directory(src: &std::path::Path, dest: &std::path::Path) -> Result<(), std::io::Error> {
+  std::fs::create_dir_all(dest)?;
+  for entry in std::fs::read_dir(src)? {
+    let entry = entry?;
+    if entry.path().is_file() {
+      std::fs::copy(entry.path(), dest.join(entry.file_name()))?;
+    }
+  }
+  Ok(())
+}
+
+#[cfg(not(feature = "dox"))]
+fn copy_cef_runtime_files(cef_dir: &std::path::Path, target_dir: &std::path::Path) -> Result<(), std::io::Error> {
+  copy_directory(cef_dir, target_dir)?;
+
+  const LOCALES_DIR: &str = "locales";
+  copy_directory(&cef_dir.join(LOCALES_DIR), &target_dir.join(LOCALES_DIR))?;
+
+  Ok(())
 }
 
 #[cfg(feature = "dox")]


### PR DESCRIPTION
Also fixes path handling issues on Windows in `download-cef` where / and \ where mixed in paths.

I can't remember the whole context of this change tbh but the main thing was that when we do this in tauri-build it resulted in the cef-dll-sys build script running twice which caused consistent build failures.
The idea here was to move the copy logic out of tauri-cli into the build crates so that iirc it would work with just cargo commands or in IDEs.

This change unfortunately does not properly work with cargo's new-ish build-dir config