### PR TITLE
fix(osr): correct double colon in the example start URL

### DIFF
--- a/examples/osr/src/main.rs
+++ b/examples/osr/src/main.rs
@@ -297,7 +297,7 @@ impl ApplicationHandler for App {
         let browser = cef::browser_host_create_browser_sync(
             Some(&window_info),
             Some(&mut ClientBuilder::build(render_handler)),
-            Some(&"https:://github.com".into()),
+            Some(&"https://github.com".into()),
             Some(&browser_settings),
             None,
             context.as_mut(),


### PR DESCRIPTION
Fixes the `osr` example's start URL, which had a double colon:

```diff
-            Some(&"https:://github.com".into()),
+            Some(&"https://github.com".into()),
```

`https:://github.com` is not a valid URL, so the example loaded an error page rather than
github.com.

Worth fixing beyond the wrong page: an error page is nearly static, so it produces very
few `OnAcceleratedPaint` callbacks. Anyone using this example to verify the shared-texture
path sees a frame count far below what the hardware delivers and can reasonably conclude
the accelerated path is broken when it is working correctly.

Closes #472
