### PR TITLE
fix: test warning about unused import

### DIFF
--- a/cef/src/bindings/mod.rs
+++ b/cef/src/bindings/mod.rs
@@ -40,7 +40,6 @@ pub use aarch64_apple_darwin::*;
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use crate::*;
     use std::cell::RefCell;
 


### PR DESCRIPTION
The `use super::*;` was redundant with the `use crate::*;` in the `test` module.